### PR TITLE
Add Github Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,119 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  php-cs-fixer:
+    name: PHP CS Fixer (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        php:
+          - '8.3'
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ffi, grpc, mbstring, opentelemetry, grpc
+          ini-values: memory_limit=-1
+          tools: pecl, composer, php-cs-fixer
+          coverage: none
+      - name: Run PHP-CS-Fixer fix
+        run: php-cs-fixer fix --dry-run --diff --ansi
+
+  phpstan:
+    name: PHPStan (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        php:
+          - '8.3'
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: pecl, composer
+          extensions: ffi, grpc, mbstring, opentelemetry, grpc
+          coverage: none
+          ini-values: memory_limit=-1
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Update project dependencies
+        run: |
+          composer update --no-interaction --no-progress --ansi
+      - name: Cache PHPStan results
+        uses: actions/cache@v3
+        with:
+          path: /tmp/phpstan
+          key: phpstan-php${{ matrix.php }}-${{ github.sha }}
+          restore-keys: |
+            phpstan-php${{ matrix.php }}-
+            phpstan-
+        continue-on-error: true
+      - name: Run PHPStan analysis
+        run: |
+          ./vendor/bin/phpstan --version
+          ./vendor/bin/phpstan analyse --no-interaction --no-progress --ansi
+
+  phpunit:
+    name: PHPUnit (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        php:
+          - '8.2'
+          - '8.3'
+        include:
+          - php: '8.2'
+            coverage: true
+          - php: '8.3'
+            coverage: true
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: pecl, composer
+          extensions: ffi, grpc, mbstring, opentelemetry, grpc
+          coverage: false
+          ini-values: memory_limit=-1
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Update project dependencies
+        run: composer update --no-interaction --no-progress --ansi
+      - name: Run PHPUnit tests
+        run: vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
+      - name: List PHP extensions
+        run: php -m
       - name: Update project dependencies
         run: |
           composer update --no-interaction --no-progress --ansi
@@ -73,6 +75,8 @@ jobs:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
+      - name: List PHP extensions
+        run: php -m
       - name: Update project dependencies
         run: |
           composer update --no-interaction --no-progress --ansi
@@ -125,6 +129,8 @@ jobs:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
+      - name: List PHP extensions
+        run: php -m
       - name: Update project dependencies
         run: composer update --no-interaction --no-progress --ansi
       - name: Run PHPUnit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,22 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: ffi, grpc, mbstring, opentelemetry, grpc, xdebug
           ini-values: memory_limit=-1
-          tools: pecl, composer, php-cs-fixer
+          tools: pecl, composer
           coverage: none
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Update project dependencies
+        run: |
+          composer update --no-interaction --no-progress --ansi
       - name: Run PHP-CS-Fixer fix
-        run: php-cs-fixer fix --dry-run --diff --ansi
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff --ansi
 
   phpstan:
     name: PHPStan (PHP ${{ matrix.php }})
@@ -102,7 +114,7 @@ jobs:
           php-version: ${{ matrix.php }}
           tools: pecl, composer
           extensions: ffi, grpc, mbstring, opentelemetry, grpc, xdebug
-          coverage: false
+          coverage: none
           ini-values: memory_limit=-1
       - name: Get composer cache directory
         id: composercache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: ffi, grpc, mbstring, opentelemetry, grpc
+          extensions: ffi, grpc, mbstring, opentelemetry, grpc, xdebug
           ini-values: memory_limit=-1
           tools: pecl, composer, php-cs-fixer
           coverage: none
@@ -49,7 +49,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           tools: pecl, composer
-          extensions: ffi, grpc, mbstring, opentelemetry, grpc
+          extensions: ffi, grpc, mbstring, opentelemetry, grpc, xdebug
           coverage: none
           ini-values: memory_limit=-1
       - name: Get composer cache directory
@@ -101,7 +101,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           tools: pecl, composer
-          extensions: ffi, grpc, mbstring, opentelemetry, grpc
+          extensions: ffi, grpc, mbstring, opentelemetry, grpc, xdebug
           coverage: false
           ini-values: memory_limit=-1
       - name: Get composer cache directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: ffi, grpc, mbstring, opentelemetry, grpc, xdebug
+          extensions: ffi, grpc, mbstring, opentelemetry, grpc
           ini-values: memory_limit=-1
           tools: pecl, composer
           coverage: none
@@ -63,7 +63,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           tools: pecl, composer
-          extensions: ffi, grpc, mbstring, opentelemetry, grpc, xdebug
+          extensions: ffi, grpc, mbstring, opentelemetry, grpc
           coverage: none
           ini-values: memory_limit=-1
       - name: Get composer cache directory
@@ -117,7 +117,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           tools: pecl, composer
-          extensions: ffi, grpc, mbstring, opentelemetry, grpc, xdebug
+          extensions: ffi, grpc, mbstring, opentelemetry, grpc
           coverage: none
           ini-values: memory_limit=-1
       - name: Get composer cache directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: php -m
       - name: Update project dependencies
         run: |
-          composer update --no-interaction --no-progress --ansi
+          composer update --ignore-platform-req=ext-xdebug --no-interaction --no-progress --ansi
       - name: Run PHP-CS-Fixer fix
         run: vendor/bin/php-cs-fixer fix --dry-run --diff --ansi
 
@@ -79,7 +79,7 @@ jobs:
         run: php -m
       - name: Update project dependencies
         run: |
-          composer update --no-interaction --no-progress --ansi
+          composer update --ignore-platform-req=ext-xdebug --no-interaction --no-progress --ansi
       - name: Cache PHPStan results
         uses: actions/cache@v3
         with:
@@ -132,6 +132,6 @@ jobs:
       - name: List PHP extensions
         run: php -m
       - name: Update project dependencies
-        run: composer update --no-interaction --no-progress --ansi
+        run: composer update --ignore-platform-req=ext-xdebug --no-interaction --no-progress --ansi
       - name: Run PHPUnit tests
         run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # opentelemetry-bundle
 
+[![GitHub Actions: CI][github-actions-ci-badge]][github-actions-ci-page]
 [![Project stage: Research][project-stage-badge]][project-stage-page]
 [![Built with Nix][build-with-nix-badge]][build-with-nix-page]
 
 > [WIP] Symfony Bundle for OpenTelemetry PHP
 
+[github-actions-ci-badge]: https://github.com/FriendsOfOpenTelemtry/opentelemetry-bundle/workflows/CI/badge.svg?branch=main
+[github-actions-ci-page]: https://github.com/FriendsOfOpenTelemtry/opentelemetry-bundle/actions?query=workflow%3ACI+branch%3Amain
 [build-with-nix-badge]: https://img.shields.io/badge/Built_With-Nix-5277C3.svg?logo=nixos
 [build-with-nix-page]: https://builtwithnix.org/
 [project-stage-badge]: https://img.shields.io/badge/Project_Stage-Research-orange.svg

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
          beStrictAboutTodoAnnotatedTests="true"
          convertDeprecationsToExceptions="true"
          failOnRisky="true"
-         failOnWarning="true"
+         failOnWarning="false"
          verbose="true">
 
     <php>

--- a/src/EventSubscriber/ConsoleMetricEventSubscriber.php
+++ b/src/EventSubscriber/ConsoleMetricEventSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\EventSubscriber;
 
-use OpenTelemetry\API\Metrics\MeterInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
@@ -13,11 +12,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class ConsoleMetricEventSubscriber implements EventSubscriberInterface
 {
-    public function __construct(
-        private readonly MeterInterface $meter,
-    ) {
-    }
-
     public static function getSubscribedEvents(): array
     {
         return [


### PR DESCRIPTION
This PR adds a Github Actions CI workflow to continuously assert that php-cs-fixer, phpstan and phpunit runs fine.