### PR TITLE
Add Roave Backwards Compatibility Check

### DIFF
--- a/.github/workflows/roave-bc-check.yml
+++ b/.github/workflows/roave-bc-check.yml
@@ -1,0 +1,41 @@
+name: Roave Backwards Compatibility Check
+on:
+  push:
+  pull_request:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v9
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v13
+        with:
+          name: opentelemetry
+          extraPullNames: nix-shell, php-src-nix
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: Setup Nix magic cache
+        uses: DeterminateSystems/magic-nix-cache-action@v2
+      - name: Instantiate Nix develop
+        uses: nicknovitski/nix-develop@v1
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: List PHP installed extensions
+        run: php -m
+      - name: Update project dependencies
+        run: |
+          composer update --no-interaction --no-progress --ansi
+      - name: Check for BC breaks
+        run: composer check-bcs

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         "phpstan/phpstan-symfony": "^1.3",
         "phpunit/phpunit": "^9.6",
         "pyrech/composer-changelogs": "^2.1",
+        "roave/backward-compatibility-check": "^8.6",
         "roave/security-advisories": "dev-master",
         "symfony/cache": "^6.4 || ^7.0",
         "symfony/framework-bundle": "^6.4 || ^7.0",
@@ -117,6 +118,7 @@
     },
     "scripts": {
         "check-reqs": "@php vendor/bin/composer-require-checker check",
+        "check-bcs": "@php vendor/bin/roave-backward-compatibility-check --format=github-actions",
         "format": [
             "@php-cs-fixer:fix",
             "@composer normalize"


### PR DESCRIPTION
This PR adds [Roave Backwards Compatibility Check](https://github.com/Roave/BackwardCompatibilityCheck) as a composer script and a new Github Action workflow. 