### PR TITLE
fix(TraceableHttpClient): span finishes too early

### DIFF
--- a/src/Instrumentation/Symfony/HttpClient/TraceableHttpClient.php
+++ b/src/Instrumentation/Symfony/HttpClient/TraceableHttpClient.php
@@ -3,7 +3,6 @@
 namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\HttpClient;
 
 use Nyholm\Psr7\Uri;
-use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
@@ -63,12 +62,9 @@ final class TraceableHttpClient implements HttpClientInterface, LoggerAwareInter
         } catch (ExceptionInterface $exception) {
             $span->recordException($exception, [TraceAttributes::EXCEPTION_ESCAPED => true]);
             $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
+            $this->logger?->debug(sprintf('Ending span "%s"', $span->getContext()->getSpanId()));
+            $span->end();
             throw $exception;
-        } finally {
-            if ($span instanceof SpanInterface) {
-                $this->logger?->debug(sprintf('Ending span "%s"', $span->getContext()->getSpanId()));
-                $span->end();
-            }
         }
     }
 

--- a/tests/Functional/Instrumentation/HttpClientTracingTest.php
+++ b/tests/Functional/Instrumentation/HttpClientTracingTest.php
@@ -51,6 +51,7 @@ final class HttpClientTracingTest extends KernelTestCase
             'url.query' => '',
             'url.fragment' => '',
             'http.request.method' => 'GET',
+            'http.response.status_code' => 200,
         ]);
         self::assertSpanEventsCount($mainSpan, 0);
     }
@@ -82,7 +83,7 @@ final class HttpClientTracingTest extends KernelTestCase
 
         $mainSpan = self::getSpans()[0];
         self::assertSpanName($mainSpan, 'http.client');
-        self::assertSpanStatus($mainSpan, StatusData::unset());
+        self::assertSpanStatus($mainSpan, StatusData::error());
         self::assertSpanAttributes($mainSpan, [
             'url.full' => 'http://localhost/failure',
             'url.scheme' => 'http',
@@ -90,6 +91,7 @@ final class HttpClientTracingTest extends KernelTestCase
             'url.query' => '',
             'url.fragment' => '',
             'http.request.method' => 'GET',
+            'http.response.status_code' => 500,
         ]);
         self::assertSpanEventsCount($mainSpan, 0);
     }
@@ -124,6 +126,7 @@ final class HttpClientTracingTest extends KernelTestCase
             'url.query' => '',
             'url.fragment' => '',
             'http.request.method' => 'GET',
+            'http.response.status_code' => 200,
         ]);
         self::assertSpanEventsCount($mainSpan, 0);
     }
@@ -179,6 +182,7 @@ final class HttpClientTracingTest extends KernelTestCase
             'url.query' => '',
             'url.fragment' => '',
             'http.request.method' => 'GET',
+            'http.response.status_code' => 200,
         ]);
         self::assertSpanEventsCount($mainSpan, 0);
     }


### PR DESCRIPTION
The client works asynchronously. Due to the `finally` construction, the span is immediately closed, without reflecting the actual result of the request. `TraceableResponse` class already finished span correctly.