### PR TITLE
fix(DependencyInjection): pass configured resource info to providers

### DIFF
--- a/src/DependencyInjection/OpenTelemetryExtension.php
+++ b/src/DependencyInjection/OpenTelemetryExtension.php
@@ -57,6 +57,14 @@ final class OpenTelemetryExtension extends ConfigurableExtension
         $container->setParameter('open_telemetry.service.name', $config['name']);
         $container->setParameter('open_telemetry.service.version', $config['version']);
         $container->setParameter('open_telemetry.service.environment', $config['environment']);
+
+        $container->getDefinition('open_telemetry.resource_info')
+            ->setArguments([
+                $config['namespace'],
+                $config['name'],
+                $config['version'],
+                $config['environment'],
+            ]);
     }
 
     /**

--- a/src/DependencyInjection/OpenTelemetryLogsExtension.php
+++ b/src/DependencyInjection/OpenTelemetryLogsExtension.php
@@ -118,6 +118,7 @@ final class OpenTelemetryLogsExtension
             ->setFactory([new Reference(sprintf('open_telemetry.logs.provider_factory.%s', $config['type'])), 'createProvider'])
             ->setArguments([
                 isset($config['processor']) ? new Reference($config['processor']) : null,
+                new Reference('open_telemetry.resource_info'),
             ]);
     }
 

--- a/src/DependencyInjection/OpenTelemetryMetricsExtension.php
+++ b/src/DependencyInjection/OpenTelemetryMetricsExtension.php
@@ -101,6 +101,7 @@ final class OpenTelemetryMetricsExtension
             ->setArguments([
                 isset($config['exporter']) ? new Reference($config['exporter']) : null,
                 $filter,
+                new Reference('open_telemetry.resource_info'),
             ]);
     }
 

--- a/src/DependencyInjection/OpenTelemetryTracesExtension.php
+++ b/src/DependencyInjection/OpenTelemetryTracesExtension.php
@@ -127,6 +127,7 @@ final class OpenTelemetryTracesExtension
             ->setArguments([
                 $sampler,
                 isset($config['processors']) ? array_map(fn (string $processor) => new Reference($processor), $config['processors']) : null,
+                new Reference('open_telemetry.resource_info'),
             ]);
     }
 

--- a/src/OpenTelemetry/Log/LoggerProvider/DefaultLoggerProviderFactory.php
+++ b/src/OpenTelemetry/Log/LoggerProvider/DefaultLoggerProviderFactory.php
@@ -7,15 +7,16 @@ use OpenTelemetry\SDK\Logs\LoggerProvider;
 use OpenTelemetry\SDK\Logs\LoggerProviderInterface;
 use OpenTelemetry\SDK\Logs\LogRecordLimitsBuilder;
 use OpenTelemetry\SDK\Logs\LogRecordProcessorInterface;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 
 final class DefaultLoggerProviderFactory extends AbstractLoggerProviderFactory
 {
-    public function createProvider(?LogRecordProcessorInterface $processor = null): LoggerProviderInterface
+    public function createProvider(?LogRecordProcessorInterface $processor = null, ?ResourceInfo $resource = null): LoggerProviderInterface
     {
         $instrumentationScopeFactory = new InstrumentationScopeFactory((new LogRecordLimitsBuilder())->build()->getAttributeFactory());
 
         assert($processor instanceof LogRecordProcessorInterface);
 
-        return new LoggerProvider($processor, $instrumentationScopeFactory);
+        return new LoggerProvider($processor, $instrumentationScopeFactory, $resource);
     }
 }

--- a/src/OpenTelemetry/Log/LoggerProvider/LoggerProviderFactoryInterface.php
+++ b/src/OpenTelemetry/Log/LoggerProvider/LoggerProviderFactoryInterface.php
@@ -4,8 +4,9 @@ namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\OpenTelemetry\Log\LoggerPro
 
 use OpenTelemetry\SDK\Logs\LoggerProviderInterface;
 use OpenTelemetry\SDK\Logs\LogRecordProcessorInterface;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 
 interface LoggerProviderFactoryInterface
 {
-    public function createProvider(?LogRecordProcessorInterface $processor = null): LoggerProviderInterface;
+    public function createProvider(?LogRecordProcessorInterface $processor = null, ?ResourceInfo $resource = null): LoggerProviderInterface;
 }

--- a/src/OpenTelemetry/Log/LoggerProvider/NoopLoggerProviderFactory.php
+++ b/src/OpenTelemetry/Log/LoggerProvider/NoopLoggerProviderFactory.php
@@ -5,10 +5,11 @@ namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\OpenTelemetry\Log\LoggerPro
 use OpenTelemetry\SDK\Logs\LoggerProviderInterface;
 use OpenTelemetry\SDK\Logs\LogRecordProcessorInterface;
 use OpenTelemetry\SDK\Logs\NoopLoggerProvider;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 
 final class NoopLoggerProviderFactory extends AbstractLoggerProviderFactory
 {
-    public function createProvider(?LogRecordProcessorInterface $processor = null): LoggerProviderInterface
+    public function createProvider(?LogRecordProcessorInterface $processor = null, ?ResourceInfo $resource = null): LoggerProviderInterface
     {
         return new NoopLoggerProvider();
     }

--- a/src/OpenTelemetry/Metric/MeterProvider/DefaultMeterProviderFactory.php
+++ b/src/OpenTelemetry/Metric/MeterProvider/DefaultMeterProviderFactory.php
@@ -7,17 +7,17 @@ use OpenTelemetry\SDK\Metrics\MeterProvider;
 use OpenTelemetry\SDK\Metrics\MeterProviderInterface;
 use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 use OpenTelemetry\SDK\Metrics\MetricReader\ExportingReader;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
 
 final class DefaultMeterProviderFactory extends AbstractMeterProviderFactory
 {
-    public function createProvider(MetricExporterInterface $exporter, ExemplarFilterInterface $filter): MeterProviderInterface
+    public function createProvider(MetricExporterInterface $exporter, ExemplarFilterInterface $filter, ?ResourceInfo $resource = null): MeterProviderInterface
     {
         $reader = new ExportingReader($exporter);
-        $resource = ResourceInfoFactory::defaultResource();
 
         return MeterProvider::builder()
-            ->setResource($resource)
+            ->setResource($resource ?? ResourceInfoFactory::defaultResource())
             ->addReader($reader)
             ->setExemplarFilter($filter)
             ->build();

--- a/src/OpenTelemetry/Metric/MeterProvider/MeterProviderFactoryInterface.php
+++ b/src/OpenTelemetry/Metric/MeterProvider/MeterProviderFactoryInterface.php
@@ -5,8 +5,9 @@ namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\OpenTelemetry\Metric\MeterP
 use OpenTelemetry\SDK\Metrics\Exemplar\ExemplarFilterInterface;
 use OpenTelemetry\SDK\Metrics\MeterProviderInterface;
 use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 
 interface MeterProviderFactoryInterface
 {
-    public function createProvider(MetricExporterInterface $exporter, ExemplarFilterInterface $filter): MeterProviderInterface;
+    public function createProvider(MetricExporterInterface $exporter, ExemplarFilterInterface $filter, ?ResourceInfo $resource = null): MeterProviderInterface;
 }

--- a/src/OpenTelemetry/Metric/MeterProvider/NoopMeterProviderFactory.php
+++ b/src/OpenTelemetry/Metric/MeterProvider/NoopMeterProviderFactory.php
@@ -6,10 +6,11 @@ use OpenTelemetry\SDK\Metrics\Exemplar\ExemplarFilterInterface;
 use OpenTelemetry\SDK\Metrics\MeterProviderInterface;
 use OpenTelemetry\SDK\Metrics\MetricExporterInterface;
 use OpenTelemetry\SDK\Metrics\NoopMeterProvider;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 
 final class NoopMeterProviderFactory extends AbstractMeterProviderFactory
 {
-    public function createProvider(?MetricExporterInterface $exporter = null, ?ExemplarFilterInterface $filter = null): MeterProviderInterface
+    public function createProvider(?MetricExporterInterface $exporter = null, ?ExemplarFilterInterface $filter = null, ?ResourceInfo $resource = null): MeterProviderInterface
     {
         return new NoopMeterProvider();
     }

--- a/src/OpenTelemetry/Resource/ResourceInfoFactory.php
+++ b/src/OpenTelemetry/Resource/ResourceInfoFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\OpenTelemetry\Resource;
+
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
+use OpenTelemetry\SemConv\ResourceAttributes;
+
+final class ResourceInfoFactory
+{
+    public static function create(string $namespace, string $name, string $version, string $environment): ResourceInfo
+    {
+        $resourceInfo = \OpenTelemetry\SDK\Resource\ResourceInfoFactory::defaultResource();
+
+        return $resourceInfo->merge(ResourceInfo::create(Attributes::create([
+            ResourceAttributes::SERVICE_NAMESPACE => $namespace,
+            ResourceAttributes::SERVICE_NAME => $name,
+            ResourceAttributes::SERVICE_VERSION => $version,
+            ResourceAttributes::DEPLOYMENT_ENVIRONMENT_NAME => $environment,
+        ]), ResourceAttributes::SCHEMA_URL));
+    }
+}

--- a/src/OpenTelemetry/Trace/TracerProvider/DefaultTracerProviderFactory.php
+++ b/src/OpenTelemetry/Trace/TracerProvider/DefaultTracerProviderFactory.php
@@ -2,18 +2,19 @@
 
 namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\OpenTelemetry\Trace\TracerProvider;
 
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Trace\SamplerInterface;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use OpenTelemetry\SDK\Trace\TracerProviderInterface;
 
 final readonly class DefaultTracerProviderFactory extends AbstractTracerProviderFactory
 {
-    public function createProvider(?SamplerInterface $sampler = null, array $processors = []): TracerProviderInterface
+    public function createProvider(?SamplerInterface $sampler = null, array $processors = [], ?ResourceInfo $info = null): TracerProviderInterface
     {
         if (0 >= count($processors)) {
             throw new \InvalidArgumentException('Processors should not be empty');
         }
 
-        return new TracerProvider($processors, $sampler);
+        return new TracerProvider($processors, $sampler, $info);
     }
 }

--- a/src/OpenTelemetry/Trace/TracerProvider/NoopTracerProviderFactory.php
+++ b/src/OpenTelemetry/Trace/TracerProvider/NoopTracerProviderFactory.php
@@ -2,13 +2,14 @@
 
 namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\OpenTelemetry\Trace\TracerProvider;
 
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Trace\NoopTracerProvider;
 use OpenTelemetry\SDK\Trace\SamplerInterface;
 use OpenTelemetry\SDK\Trace\TracerProviderInterface;
 
 final readonly class NoopTracerProviderFactory extends AbstractTracerProviderFactory
 {
-    public function createProvider(?SamplerInterface $sampler = null, array $processors = []): TracerProviderInterface
+    public function createProvider(?SamplerInterface $sampler = null, array $processors = [], ?ResourceInfo $info = null): TracerProviderInterface
     {
         return new NoopTracerProvider();
     }

--- a/src/OpenTelemetry/Trace/TracerProvider/TracerProviderFactoryInterface.php
+++ b/src/OpenTelemetry/Trace/TracerProvider/TracerProviderFactoryInterface.php
@@ -2,6 +2,7 @@
 
 namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\OpenTelemetry\Trace\TracerProvider;
 
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SDK\Trace\SamplerInterface;
 use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
 use OpenTelemetry\SDK\Trace\TracerProviderInterface;
@@ -11,5 +12,5 @@ interface TracerProviderFactoryInterface
     /**
      * @param SpanProcessorInterface[] $processors
      */
-    public function createProvider(?SamplerInterface $sampler = null, array $processors = []): TracerProviderInterface;
+    public function createProvider(?SamplerInterface $sampler = null, array $processors = [], ?ResourceInfo $info = null): TracerProviderInterface;
 }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -3,6 +3,7 @@
 use FriendsOfOpenTelemetry\OpenTelemetryBundle\OpenTelemetry\Context\Propagator\HeadersPropagator as HeadersPropagationGetter;
 use FriendsOfOpenTelemetry\OpenTelemetryBundle\OpenTelemetry\Exporter\ExporterDsn;
 use FriendsOfOpenTelemetry\OpenTelemetryBundle\OpenTelemetry\Exporter\OtlpExporterOptions;
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\OpenTelemetry\Resource\ResourceInfoFactory;
 use FriendsOfOpenTelemetry\OpenTelemetryBundle\OpenTelemetryBundle;
 use OpenTelemetry\Context\Propagation\ArrayAccessGetterSetter;
 use OpenTelemetry\Context\Propagation\MultiTextMapPropagator;
@@ -10,6 +11,7 @@ use OpenTelemetry\Context\Propagation\NoopTextMapPropagator;
 use OpenTelemetry\Context\Propagation\SanitizeCombinedHeadersPropagationGetter;
 use OpenTelemetry\Contrib\Propagation\ServerTiming\ServerTimingPropagator;
 use OpenTelemetry\Contrib\Propagation\TraceResponse\TraceResponsePropagator;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $container): void {
@@ -22,6 +24,9 @@ return static function (ContainerConfigurator $container): void {
     $container->services()
         ->defaults()
         ->private()
+
+        ->set('open_telemetry.resource_info', ResourceInfo::class)
+            ->factory([ResourceInfoFactory::class, 'create'])
 
         ->set('open_telemetry.propagator.server_timing', ServerTimingPropagator::class)
         ->set('open_telemetry.propagator.trace_response', TraceResponsePropagator::class)

--- a/tests/Unit/DependencyInjection/OpenTelemetryExtensionTest.php
+++ b/tests/Unit/DependencyInjection/OpenTelemetryExtensionTest.php
@@ -19,6 +19,7 @@ use OpenTelemetry\Context\Propagation\NoopTextMapPropagator;
 use OpenTelemetry\Context\Propagation\SanitizeCombinedHeadersPropagationGetter;
 use OpenTelemetry\Contrib\Propagation\ServerTiming\ServerTimingPropagator;
 use OpenTelemetry\Contrib\Propagation\TraceResponse\TraceResponsePropagator;
+use OpenTelemetry\SDK\Resource\ResourceInfo;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -66,6 +67,8 @@ class OpenTelemetryExtensionTest extends AbstractExtensionTestCase
     public function testDefaultServices(): void
     {
         $this->load();
+
+        self::assertContainerBuilderHasService('open_telemetry.resource_info', ResourceInfo::class);
 
         self::assertContainerBuilderHasService('open_telemetry.propagator.server_timing', ServerTimingPropagator::class);
         self::assertContainerBuilderHasService('open_telemetry.propagator.trace_response', TraceResponsePropagator::class);

--- a/tests/Unit/DependencyInjection/OpenTelemetryLogsExtensionTest.php
+++ b/tests/Unit/DependencyInjection/OpenTelemetryLogsExtensionTest.php
@@ -346,6 +346,11 @@ class OpenTelemetryLogsExtensionTest extends AbstractExtensionTestCase
             0,
             null !== $processor ? new Reference($processor) : null,
         );
+        self::assertContainerBuilderHasServiceDefinitionWithArgument(
+            'open_telemetry.logs.providers.main',
+            1,
+            new Reference('open_telemetry.resource_info'),
+        );
         $provider = $this->container->getDefinition('open_telemetry.logs.providers.main');
         self::assertEquals([new Reference(sprintf('open_telemetry.logs.provider_factory.%s', $type)), 'createProvider'], $provider->getFactory());
     }

--- a/tests/Unit/DependencyInjection/OpenTelemetryMetricsExtensionTest.php
+++ b/tests/Unit/DependencyInjection/OpenTelemetryMetricsExtensionTest.php
@@ -251,6 +251,11 @@ class OpenTelemetryMetricsExtensionTest extends AbstractExtensionTestCase
             1,
             (new ChildDefinition('open_telemetry.metrics.exemplar_filter_factory'))->setArguments([$filter]),
         );
+        self::assertContainerBuilderHasServiceDefinitionWithArgument(
+            'open_telemetry.metrics.providers.main',
+            2,
+            new Reference('open_telemetry.resource_info'),
+        );
         $provider = $this->container->getDefinition('open_telemetry.metrics.providers.main');
         self::assertEquals([new Reference(sprintf('open_telemetry.metrics.provider_factory.%s', $type)), 'createProvider'], $provider->getFactory());
     }

--- a/tests/Unit/DependencyInjection/OpenTelemetryTracesExtensionTest.php
+++ b/tests/Unit/DependencyInjection/OpenTelemetryTracesExtensionTest.php
@@ -357,6 +357,11 @@ class OpenTelemetryTracesExtensionTest extends AbstractExtensionTestCase
             1,
             null !== $processors ? array_map(fn (string $processor) => new Reference($processor), $processors) : [],
         );
+        self::assertContainerBuilderHasServiceDefinitionWithArgument(
+            'open_telemetry.traces.providers.main',
+            2,
+            new Reference('open_telemetry.resource_info'),
+        );
         $provider = $this->container->getDefinition('open_telemetry.traces.providers.main');
         self::assertEquals([new Reference(sprintf('open_telemetry.traces.provider_factory.%s', $type)), 'createProvider'], $provider->getFactory());
     }

--- a/tests/Unit/OpenTelemetry/Resource/ResourceInfoFactoryTest.php
+++ b/tests/Unit/OpenTelemetry/Resource/ResourceInfoFactoryTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\Tests\Unit\OpenTelemetry\Resource;
+
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\OpenTelemetry\Resource\ResourceInfoFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResourceInfoFactory::class)]
+class ResourceInfoFactoryTest extends TestCase
+{
+    public function testCreateResourceInfo(): void
+    {
+        $resource = ResourceInfoFactory::create('FriendsOfOpenTelemetry/OpenTelemetry', 'Test', '0.0.0', 'test');
+
+        $attributes = $resource->getAttributes();
+        self::assertSame('FriendsOfOpenTelemetry/OpenTelemetry', $attributes->get('service.namespace'));
+        self::assertSame('Test', $attributes->get('service.name'));
+        self::assertSame('0.0.0', $attributes->get('service.version'));
+        self::assertSame('test', $attributes->get('deployment.environment.name'));
+    }
+}


### PR DESCRIPTION
This PR adds a ResourceInfoFactory based on OpenTelemetry ResourceInfoFactory. A custom resource info is now injected to providers so it configure the `open_telemetry.service` parameters.

Closes #104.