### PR TITLE
refactor(config): Prototype of config separation and auto loading

### DIFF
--- a/src/DependencyInjection/OpenTelemetryExtension.php
+++ b/src/DependencyInjection/OpenTelemetryExtension.php
@@ -2,27 +2,11 @@
 
 namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\DependencyInjection;
 
-use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\InstrumentationTypeEnum;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
-/**
- * @phpstan-type InstrumentationConfig array{
- *     type?: string,
- *     tracing: TracingInstrumentationConfig,
- *     metering: MeteringInstrumentationConfig,
- * }
- * @phpstan-type TracingInstrumentationConfig array{
- *     enabled: bool,
- *     tracer: ?string,
- * }
- * @phpstan-type MeteringInstrumentationConfig array{
- *     enabled: bool,
- *     meter: ?string,
- * }
- */
 final class OpenTelemetryExtension extends ConfigurableExtension
 {
     protected function loadInternal(array $mergedConfig, ContainerBuilder $container): void
@@ -33,11 +17,10 @@ final class OpenTelemetryExtension extends ConfigurableExtension
         $loader->load('services_logs.php');
         $loader->load('services_metrics.php');
         $loader->load('services_traces.php');
-        $loader->load('services_tracing_instrumentation.php');
 
         $this->loadServiceParams($mergedConfig['service'], $container);
-        $this->loadInstrumentationParams($mergedConfig['instrumentation'], $container);
 
+        (new OpenTelemetryInstrumentationExtension())($mergedConfig['instrumentation'], $container, $loader);
         (new OpenTelemetryTracesExtension())($mergedConfig['traces'], $container);
         (new OpenTelemetryMetricsExtension())($mergedConfig['metrics'], $container);
         (new OpenTelemetryLogsExtension())($mergedConfig['logs'], $container);
@@ -65,45 +48,5 @@ final class OpenTelemetryExtension extends ConfigurableExtension
                 $config['version'],
                 $config['environment'],
             ]);
-    }
-
-    /**
-     * @param array{
-     *     cache: InstrumentationConfig,
-     *     console: InstrumentationConfig,
-     *     doctrine: InstrumentationConfig,
-     *     http_client: InstrumentationConfig,
-     *     http_kernel: InstrumentationConfig,
-     *     mailer: InstrumentationConfig,
-     *     messenger: InstrumentationConfig,
-     *     twig: InstrumentationConfig,
-     * } $config
-     */
-    private function loadInstrumentationParams(array $config, ContainerBuilder $container): void
-    {
-        foreach ($config as $name => $instrumentation) {
-            $container->setParameter(
-                sprintf('open_telemetry.instrumentation.%s.tracing.enabled', $name),
-                $instrumentation['tracing']['enabled'],
-            );
-            if (isset($instrumentation['type'])) {
-                $container->setParameter(
-                    sprintf('open_telemetry.instrumentation.%s.type', $name),
-                    InstrumentationTypeEnum::from($instrumentation['type']),
-                );
-            }
-            $container->setParameter(
-                sprintf('open_telemetry.instrumentation.%s.tracing.tracer', $name),
-                $instrumentation['tracing']['tracer'] ?? 'default_tracer',
-            );
-            $container->setParameter(
-                sprintf('open_telemetry.instrumentation.%s.metering.enabled', $name),
-                $instrumentation['metering']['enabled'],
-            );
-            $container->setParameter(
-                sprintf('open_telemetry.instrumentation.%s.metering.meter', $name),
-                $instrumentation['metering']['meter'] ?? 'default_meter',
-            );
-        }
     }
 }

--- a/src/DependencyInjection/OpenTelemetryInstrumentationExtension.php
+++ b/src/DependencyInjection/OpenTelemetryInstrumentationExtension.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\DependencyInjection;
+
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\InstrumentationTypeEnum;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @phpstan-type InstrumentationConfig array{
+ *     type?: string,
+ *     tracing: TracingInstrumentationConfig,
+ *     metering: MeteringInstrumentationConfig,
+ * }
+ * @phpstan-type TracingInstrumentationConfig array{
+ *     enabled: bool,
+ *     tracer: ?string,
+ * }
+ * @phpstan-type MeteringInstrumentationConfig array{
+ *     enabled: bool,
+ *     meter: ?string,
+ * }
+ */
+final class OpenTelemetryInstrumentationExtension
+{
+    /**
+     * @param array{
+     *     cache: InstrumentationConfig,
+     *     console: InstrumentationConfig,
+     *     doctrine: InstrumentationConfig,
+     *     http_client: InstrumentationConfig,
+     *     http_kernel: InstrumentationConfig,
+     *     mailer: InstrumentationConfig,
+     *     messenger: InstrumentationConfig,
+     *     twig: InstrumentationConfig,
+     * } $config
+     */
+    public function __invoke(array $config, ContainerBuilder $container, LoaderInterface $loader): void
+    {
+        foreach ($config as $name => $instrumentation) {
+            $container->setParameter(
+                sprintf('open_telemetry.instrumentation.%s.tracing.enabled', $name),
+                $instrumentation['tracing']['enabled'],
+            );
+
+            if (isset($instrumentation['type'])) {
+                $container->setParameter(
+                    sprintf('open_telemetry.instrumentation.%s.type', $name),
+                    InstrumentationTypeEnum::from($instrumentation['type']),
+                );
+            }
+            $container->setParameter(
+                sprintf('open_telemetry.instrumentation.%s.tracing.tracer', $name),
+                $instrumentation['tracing']['tracer'] ?? 'default_tracer',
+            );
+            $container->setParameter(
+                sprintf('open_telemetry.instrumentation.%s.metering.enabled', $name),
+                $instrumentation['metering']['enabled'],
+            );
+            $container->setParameter(
+                sprintf('open_telemetry.instrumentation.%s.metering.meter', $name),
+                $instrumentation['metering']['meter'] ?? 'default_meter',
+            );
+
+            if ($instrumentation['tracing']['enabled']) {
+                $loader->load('instrumentation/'.$name.'.php');
+            }
+        }
+    }
+}

--- a/src/Resources/config/instrumentation/cache.php
+++ b/src/Resources/config/instrumentation/cache.php
@@ -1,0 +1,23 @@
+<?php
+
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\Cache\TagAwareTraceableCacheAdapter;
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\Cache\TraceableCacheAdapter;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        ->defaults()
+        ->private()
+        ->set('open_telemetry.instrumentation.cache.trace.adapter', TraceableCacheAdapter::class)
+            ->arg('$tracer', service('open_telemetry.traces.default_tracer'))
+            ->abstract()
+            ->tag('monolog.logger', ['channel' => 'open_telemetry'])
+
+        ->set('open_telemetry.instrumentation.cache.trace.tag_aware_adapter', TagAwareTraceableCacheAdapter::class)
+            ->arg('$tracer', service('open_telemetry.traces.default_tracer'))
+            ->abstract()
+            ->tag('monolog.logger', ['channel' => 'open_telemetry'])
+    ;
+};

--- a/src/Resources/config/instrumentation/console.php
+++ b/src/Resources/config/instrumentation/console.php
@@ -1,0 +1,16 @@
+<?php
+
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\Console\TraceableConsoleEventSubscriber;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        ->defaults()
+        ->private()
+        ->set('open_telemetry.instrumentation.console.trace.event_subscriber', TraceableConsoleEventSubscriber::class)
+            ->arg('$tracer', service('open_telemetry.traces.default_tracer'))
+            ->tag('kernel.event_subscriber')
+    ;
+};

--- a/src/Resources/config/instrumentation/doctrine.php
+++ b/src/Resources/config/instrumentation/doctrine.php
@@ -1,0 +1,17 @@
+<?php
+
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Doctrine\Middleware\TraceableMiddleware as TraceableDoctrineMiddleware;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        ->defaults()
+        ->private()
+        ->set('open_telemetry.instrumentation.doctrine.trace.middleware', TraceableDoctrineMiddleware::class)
+            ->arg('$tracer', service('open_telemetry.traces.default_tracer'))
+            ->tag('doctrine.middleware')
+            ->tag('monolog.logger', ['channel' => 'open_telemetry'])
+    ;
+};

--- a/src/Resources/config/instrumentation/http_client.php
+++ b/src/Resources/config/instrumentation/http_client.php
@@ -1,0 +1,16 @@
+<?php
+
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\HttpClient\TraceableHttpClient;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        ->defaults()
+        ->private()
+        ->set('open_telemetry.instrumentation.http_client.trace.client', TraceableHttpClient::class)
+            ->arg('$tracer', service('open_telemetry.traces.default_tracer'))
+            ->tag('monolog.logger', ['channel' => 'open_telemetry'])
+    ;
+};

--- a/src/Resources/config/instrumentation/http_kernel.php
+++ b/src/Resources/config/instrumentation/http_kernel.php
@@ -1,0 +1,25 @@
+<?php
+
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\Framework\Routing\TraceableRouteLoader;
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\HttpKernel\TraceableHttpKernelEventSubscriber;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        ->defaults()
+        ->private()
+        ->set('open_telemetry.instrumentation.http_kernel.trace.event_subscriber', TraceableHttpKernelEventSubscriber::class)
+            ->arg('$tracer', service('open_telemetry.traces.default_tracer'))
+            ->arg('$propagator', service('open_telemetry.propagator_text_map.noop'))
+            ->arg('$propagationGetter', service('open_telemetry.propagation_getter.headers'))
+            ->tag('kernel.event_subscriber')
+            ->tag('monolog.logger', ['channel' => 'open_telemetry'])
+
+        ->set('open_telemetry.instrumentation.http_kernel.trace.route_loader', TraceableRouteLoader::class)
+            ->decorate('routing.loader')
+            ->arg('$loader', service('.inner'))
+            ->tag('monolog.logger', ['channel' => 'open_telemetry'])
+    ;
+};

--- a/src/Resources/config/instrumentation/mailer.php
+++ b/src/Resources/config/instrumentation/mailer.php
@@ -1,0 +1,31 @@
+<?php
+
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\Mailer\TraceableMailer;
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\Mailer\TraceableMailerTransport;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        ->defaults()
+        ->private()
+        ->set('open_telemetry.instrumentation.mailer.trace.transports', TraceableMailerTransport::class)
+            ->decorate('mailer.transports')
+            ->arg('$tracer', service('open_telemetry.traces.default_tracer'))
+            ->arg('$transport', service('.inner'))
+            ->tag('monolog.logger', ['channel' => 'open_telemetry'])
+
+        ->set('open_telemetry.instrumentation.mailer.trace.default_transport', TraceableMailerTransport::class)
+            ->decorate('mailer.default_transport')
+            ->arg('$tracer', service('open_telemetry.traces.default_tracer'))
+            ->arg('$transport', service('.inner'))
+            ->tag('monolog.logger', ['channel' => 'open_telemetry'])
+
+        ->set('open_telemetry.instrumentation.mailer.trace.mailer', TraceableMailer::class)
+            ->decorate('mailer.mailer')
+            ->arg('$tracer', service('open_telemetry.traces.default_tracer'))
+            ->arg('$mailer', service('.inner'))
+            ->tag('monolog.logger', ['channel' => 'open_telemetry'])
+    ;
+};

--- a/src/Resources/config/instrumentation/messenger.php
+++ b/src/Resources/config/instrumentation/messenger.php
@@ -1,0 +1,31 @@
+<?php
+
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\Messenger\TraceableMessengerMiddleware;
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\Messenger\TraceableMessengerTransport;
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\Messenger\TraceableMessengerTransportFactory;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        ->defaults()
+        ->private()
+        ->set('open_telemetry.instrumentation.messenger.trace.transport', TraceableMessengerTransport::class)
+            ->arg('$tracer', service('open_telemetry.traces.default_tracer'))
+            ->tag('monolog.logger', ['channel' => 'open_telemetry'])
+
+        ->set('open_telemetry.instrumentation.messenger.trace.transport_factory', TraceableMessengerTransportFactory::class)
+            ->arg('$tracer', service('open_telemetry.traces.default_tracer'))
+            ->arg('$transportFactory', service('messenger.transport_factory'))
+            ->tag('messenger.transport_factory')
+            ->tag('kernel.reset', ['method' => 'reset'])
+            ->tag('monolog.logger', ['channel' => 'open_telemetry'])
+        ->alias('messenger.transport.open_telemetry_tracer.factory', 'open_telemetry.instrumentation.messenger.trace.transport_factory')
+
+        ->set('open_telemetry.instrumentation.messenger.trace.middleware', TraceableMessengerMiddleware::class)
+            ->arg('$tracer', service('open_telemetry.traces.default_tracer'))
+            ->tag('monolog.logger', ['channel' => 'open_telemetry'])
+        ->alias('messenger.middleware.open_telemetry_tracer', 'open_telemetry.instrumentation.messenger.trace.middleware')
+    ;
+};

--- a/src/Resources/config/instrumentation/twig.php
+++ b/src/Resources/config/instrumentation/twig.php
@@ -1,0 +1,17 @@
+<?php
+
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Twig\TraceableTwigExtension;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        ->defaults()
+        ->private()
+        ->set('open_telemetry.instrumentation.twig.trace.extension', TraceableTwigExtension::class)
+            ->arg('$tracer', service('open_telemetry.traces.default_tracer'))
+            ->tag('twig.extension')
+            ->tag('monolog.logger', ['channel' => 'open_telemetry'])
+    ;
+};


### PR DESCRIPTION
Services for different modules and packages are loaded only when needed. You can set tags for services and not remove them later. The container will not contain unnecessary services. You can take this idea further and include files automatically based on installed packages. @gaelreyrol 