### PR TITLE
fix(TraceableRouteLoader): fix ReflectionMethod deprecations on PHP 8.3+

### DIFF
--- a/src/Instrumentation/Symfony/Framework/Routing/TraceableRouteLoader.php
+++ b/src/Instrumentation/Symfony/Framework/Routing/TraceableRouteLoader.php
@@ -58,7 +58,11 @@ class TraceableRouteLoader implements LoaderInterface
         try {
             $controller = $route->getDefault('_controller');
             if (true === str_contains($controller, '::')) {
-                $reflection = new \ReflectionMethod($controller);
+                if (PHP_VERSION_ID < 80300) {
+                    $reflection = new \ReflectionMethod($controller);
+                } else {
+                    $reflection = \ReflectionMethod::createFromMethodName($controller);
+                }
             } else {
                 $reflection = new \ReflectionClass($controller);
             }


### PR DESCRIPTION
```
Deprecated: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead

File: /service/vendor/friendsofopentelemetry/opentelemetry-bundle/src/Instrumentation/Symfony/Framework/Routing/TraceableRouteLoader.php:61
```
Solution referrence https://github.com/nette/di/blob/59cf6994c71ac077bb7848beb80031edf29dfef4/src/DI/DependencyChecker.php#L146