### PR TITLE
fix(Instrumentation): remove/replace deprecated usage of sem-conv attribute keys

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,7 @@ parameters:
 		- src/aliases.php
 	editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
 	tmpDir: %currentWorkingDirectory%/.phpstan
+	reportUnmatchedIgnoredErrors: true
 	excludePaths:
 		- tests/*/var/*
 

--- a/src/Instrumentation/Doctrine/Middleware/TraceableConnectionV3.php
+++ b/src/Instrumentation/Doctrine/Middleware/TraceableConnectionV3.php
@@ -23,7 +23,7 @@ class TraceableConnectionV3 extends AbstractConnectionMiddleware
     public function prepare(string $sql): DriverStatement
     {
         return $this->tracer->traceFunction('doctrine.dbal.statement.prepare', function (SpanInterface $span) use ($sql): DriverStatement {
-            $span->setAttribute(TraceAttributes::DB_STATEMENT, $sql);
+            $span->setAttribute(TraceAttributes::DB_QUERY_TEXT, $sql);
 
             return new TraceableStatement(parent::prepare($sql), $this->tracer);
         });
@@ -32,7 +32,7 @@ class TraceableConnectionV3 extends AbstractConnectionMiddleware
     public function query(string $sql): Result
     {
         return $this->tracer->traceFunction('doctrine.dbal.connection.query', function (SpanInterface $span) use ($sql): Result {
-            $span->setAttribute(TraceAttributes::DB_STATEMENT, $sql);
+            $span->setAttribute(TraceAttributes::DB_QUERY_TEXT, $sql);
 
             return parent::query($sql);
         });
@@ -41,7 +41,7 @@ class TraceableConnectionV3 extends AbstractConnectionMiddleware
     public function exec(string $sql): int
     {
         return $this->tracer->traceFunction('doctrine.dbal.connection.exec', function (SpanInterface $span) use ($sql): int {
-            $span->setAttribute(TraceAttributes::DB_STATEMENT, $sql);
+            $span->setAttribute(TraceAttributes::DB_QUERY_TEXT, $sql);
 
             return parent::exec($sql);
         });

--- a/src/Instrumentation/Doctrine/Middleware/TraceableDriverV3.php
+++ b/src/Instrumentation/Doctrine/Middleware/TraceableDriverV3.php
@@ -55,10 +55,8 @@ final class TraceableDriverV3 extends AbstractDriverMiddleware
                 ->spanBuilder('doctrine.dbal.connection')
                 ->setSpanKind(SpanKind::KIND_CLIENT)
                 ->setParent($scope?->context())
-                ->setAttribute(TraceAttributes::DB_SYSTEM, $this->getSemanticDbSystem())
-                ->setAttribute(TraceAttributes::DB_CONNECTION_STRING, $params['url'] ?? $params['path'] ?? '')
-                ->setAttribute(TraceAttributes::DB_NAME, $params['dbname'] ?? 'default')
-                ->setAttribute(TraceAttributes::DB_USER, $params['user'])
+                ->setAttribute(TraceAttributes::DB_SYSTEM_NAME, $this->getSemanticDbSystem())
+                ->setAttribute(TraceAttributes::DB_NAMESPACE, $params['dbname'] ?? 'default')
             ;
 
             $span = $spanBuilder->startSpan();
@@ -71,7 +69,7 @@ final class TraceableDriverV3 extends AbstractDriverMiddleware
 
             return new TraceableConnection($connection, new Tracer($this->tracer, $this->logger));
         } catch (Exception $exception) {
-            $span->recordException($exception, [TraceAttributes::EXCEPTION_ESCAPED => true]);
+            $span->recordException($exception);
             $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
 
             throw $exception;

--- a/src/Instrumentation/Doctrine/Middleware/TraceableDriverV4.php
+++ b/src/Instrumentation/Doctrine/Middleware/TraceableDriverV4.php
@@ -67,12 +67,12 @@ final class TraceableDriverV4 extends AbstractDriverMiddleware
 
             $connection = parent::connect($params);
 
-            $span->setAttribute(TraceAttributes::DB_SYSTEM, $this->getSemanticDbSystem($connection->getServerVersion()));
+            $span->setAttribute(TraceAttributes::DB_SYSTEM_NAME, $this->getSemanticDbSystem($connection->getServerVersion()));
             $span->setStatus(StatusCode::STATUS_OK);
 
             return new TraceableConnection($connection, new Tracer($this->tracer, $this->logger));
         } catch (Exception $exception) {
-            $span->recordException($exception, [TraceAttributes::EXCEPTION_ESCAPED => true]);
+            $span->recordException($exception);
             $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
             throw $exception;
         } finally {

--- a/src/Instrumentation/Doctrine/Middleware/Tracer.php
+++ b/src/Instrumentation/Doctrine/Middleware/Tracer.php
@@ -8,7 +8,6 @@ use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Context\Context;
-use OpenTelemetry\SemConv\TraceAttributes;
 use Psr\Log\LoggerInterface;
 
 class Tracer
@@ -50,7 +49,7 @@ class Tracer
             return $callback($span);
         } catch (Exception $exception) {
             if ($span instanceof SpanInterface) {
-                $span->recordException($exception, [TraceAttributes::EXCEPTION_ESCAPED => true]);
+                $span->recordException($exception);
                 $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
             }
             throw $exception;

--- a/src/Instrumentation/Symfony/Cache/Tracer.php
+++ b/src/Instrumentation/Symfony/Cache/Tracer.php
@@ -7,7 +7,6 @@ use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Context\Context;
-use OpenTelemetry\SemConv\TraceAttributes;
 use Psr\Cache\CacheException;
 use Psr\Log\LoggerInterface;
 
@@ -49,7 +48,7 @@ class Tracer
             return $callback($span);
         } catch (CacheException $exception) {
             if ($span instanceof SpanInterface) {
-                $span->recordException($exception, [TraceAttributes::EXCEPTION_ESCAPED => true]);
+                $span->recordException($exception);
                 $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
             }
             throw $exception;

--- a/src/Instrumentation/Symfony/Console/TraceableConsoleEventSubscriber.php
+++ b/src/Instrumentation/Symfony/Console/TraceableConsoleEventSubscriber.php
@@ -70,7 +70,7 @@ final class TraceableConsoleEventSubscriber implements EventSubscriberInterface,
         $spanBuilder = $tracer
             ->spanBuilder($name)
             ->setAttributes([
-                TraceAttributes::CODE_FUNCTION => 'execute',
+                TraceAttributes::CODE_FUNCTION_NAME => 'execute',
                 TraceAttributes::CODE_NAMESPACE => $class,
             ]);
 

--- a/src/Instrumentation/Symfony/Mailer/TraceableMailer.php
+++ b/src/Instrumentation/Symfony/Mailer/TraceableMailer.php
@@ -7,7 +7,6 @@ use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Context\Context;
-use OpenTelemetry\SemConv\TraceAttributes;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\TransportException;
@@ -49,7 +48,7 @@ class TraceableMailer implements MailerInterface
             $this->mailer->send($message, $envelope);
         } catch (TransportException $exception) {
             if ($span instanceof SpanInterface) {
-                $span->recordException($exception, [TraceAttributes::EXCEPTION_ESCAPED => true]);
+                $span->recordException($exception);
                 $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
             }
             throw $exception;

--- a/src/Instrumentation/Symfony/Mailer/TraceableMailerTransport.php
+++ b/src/Instrumentation/Symfony/Mailer/TraceableMailerTransport.php
@@ -7,7 +7,6 @@ use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Context\Context;
-use OpenTelemetry\SemConv\TraceAttributes;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\TransportException;
@@ -62,7 +61,7 @@ class TraceableMailerTransport implements TransportInterface
             );
         } catch (TransportException $exception) {
             if ($span instanceof SpanInterface) {
-                $span->recordException($exception, [TraceAttributes::EXCEPTION_ESCAPED => true]);
+                $span->recordException($exception);
                 $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
             }
             throw $exception;

--- a/src/Instrumentation/Symfony/Messenger/TransportTracer.php
+++ b/src/Instrumentation/Symfony/Messenger/TransportTracer.php
@@ -7,7 +7,6 @@ use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Context\Context;
-use OpenTelemetry\SemConv\TraceAttributes;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Exception\TransportException;
 
@@ -50,7 +49,7 @@ class TransportTracer
             return $callback($span);
         } catch (TransportException $exception) {
             if (null !== $span) {
-                $span->recordException($exception, [TraceAttributes::EXCEPTION_ESCAPED => true]);
+                $span->recordException($exception);
                 $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
             }
             throw $exception;

--- a/tests/Functional/Instrumentation/ConsoleTracingTest.php
+++ b/tests/Functional/Instrumentation/ConsoleTracingTest.php
@@ -35,7 +35,7 @@ class ConsoleTracingTest extends KernelTestCase
         self::assertSpanName($mainSpan, 'traceable-command');
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributes($mainSpan, [
-            'code.function' => 'execute',
+            'code.function.name' => 'execute',
             'code.namespace' => 'App\Command\TraceableCommand',
             'symfony.console.exit_code' => 0,
         ]);
@@ -63,7 +63,7 @@ class ConsoleTracingTest extends KernelTestCase
         self::assertSpanName($mainSpan, 'traceable-command');
         self::assertSpanStatus($mainSpan, StatusData::error());
         self::assertSpanAttributes($mainSpan, [
-            'code.function' => 'execute',
+            'code.function.name' => 'execute',
             'code.namespace' => 'App\Command\TraceableCommand',
             'symfony.console.exit_code' => 1,
         ]);
@@ -96,7 +96,7 @@ class ConsoleTracingTest extends KernelTestCase
         self::assertSpanName($mainSpan, 'traceable-command');
         self::assertSpanStatus($mainSpan, StatusData::error());
         self::assertSpanAttributes($mainSpan, [
-            'code.function' => 'execute',
+            'code.function.name' => 'execute',
             'code.namespace' => 'App\Command\TraceableCommand',
             'symfony.console.exit_code' => 1,
         ]);
@@ -132,7 +132,7 @@ class ConsoleTracingTest extends KernelTestCase
         self::assertSpanName($mainSpan, 'fallback-command');
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributes($mainSpan, [
-            'code.function' => 'execute',
+            'code.function.name' => 'execute',
             'code.namespace' => 'App\Command\FallbackCommand',
             'symfony.console.exit_code' => 0,
         ]);

--- a/tests/Functional/Instrumentation/Doctrine/DoctrineV4TracingTest.php
+++ b/tests/Functional/Instrumentation/Doctrine/DoctrineV4TracingTest.php
@@ -46,6 +46,7 @@ final class DoctrineV4TracingTest extends KernelTestCase
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributesSubSet($mainSpan, [
             'db.namespace' => 'default',
+            'db.system.name' => 'sqlite',
             'doctrine.user' => 'root',
         ]);
         self::assertSpanEventsCount($mainSpan, 0);


### PR DESCRIPTION
Deprecated usage of semantic convention attributes has been removed or replaced.