### PR TITLE
chore(github): add PHP 8.2 & 8.4 version to CI matrix workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,17 @@ jobs:
         php:
           - '8.2'
           - '8.3'
+          - '8.4'
         dependencies:
           - 'highest'
         include:
+          - php: '8.4'
+            dependencies: 'highest'
+            coverage: true
           - php: '8.3'
+            dependencies: 'highest'
+            coverage: true
+          - php: '8.2'
             dependencies: 'highest'
             coverage: true
       fail-fast: false


### PR DESCRIPTION
Add PHP 8.4 to CI matrix workflow and add missing coverage for PHP 8.2