### PR TITLE
feat(Instrumentation/HttpKernel): exclude paths from being traced when instrumentation type is auto

### DIFF
--- a/src/DependencyInjection/Compiler/SetHttpKernelTracingExcludePathsPass.php
+++ b/src/DependencyInjection/Compiler/SetHttpKernelTracingExcludePathsPass.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class SetHttpKernelTracingExcludePathsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (false === $container->hasParameter('open_telemetry.instrumentation.http_kernel.tracing.exclude_paths')) {
+            return;
+        }
+
+        if (false === $container->hasDefinition('open_telemetry.instrumentation.http_kernel.trace.event_subscriber')) {
+            return;
+        }
+
+        $excludePaths = $container->getParameter('open_telemetry.instrumentation.http_kernel.tracing.exclude_paths');
+        $container->getDefinition('open_telemetry.instrumentation.http_kernel.trace.event_subscriber')
+            ->addMethodCall('setExcludePaths', [$excludePaths]);
+    }
+}

--- a/src/DependencyInjection/OpenTelemetryExtension.php
+++ b/src/DependencyInjection/OpenTelemetryExtension.php
@@ -24,6 +24,7 @@ use Symfony\Component\Messenger\Envelope;
  * @phpstan-type TracingInstrumentationConfig array{
  *     enabled: bool,
  *     tracer: ?string,
+ *     exclude_paths?: string[]
  * }
  * @phpstan-type MeteringInstrumentationConfig array{
  *     enabled: bool,
@@ -258,6 +259,18 @@ final class OpenTelemetryExtension extends ConfigurableExtension
                 InstrumentationTypeEnum::from($config['type']),
             );
         }
+
+        if ('http_kernel' === $name) {
+            if (isset($config['tracing']['exclude_paths'])
+                && 0 < \count($config['tracing']['exclude_paths'])
+            ) {
+                $container->setParameter(
+                    sprintf('open_telemetry.instrumentation.%s.tracing.exclude_paths', $name),
+                    $config['tracing']['exclude_paths'],
+                );
+            }
+        }
+
         $container->setParameter(
             sprintf('open_telemetry.instrumentation.%s.tracing.tracer', $name),
             $config['tracing']['tracer'] ?? 'default_tracer',

--- a/src/Instrumentation/Symfony/HttpKernel/TraceableHttpKernelEventSubscriber.php
+++ b/src/Instrumentation/Symfony/HttpKernel/TraceableHttpKernelEventSubscriber.php
@@ -50,6 +50,11 @@ final class TraceableHttpKernelEventSubscriber implements EventSubscriberInterfa
     private InstrumentationTypeEnum $instrumentationType = InstrumentationTypeEnum::Auto;
 
     /**
+     * @var string[]
+     */
+    private array $excludePaths = [];
+
+    /**
      * @param iterable<string> $requestHeaders
      * @param iterable<string> $responseHeaders
      */
@@ -276,7 +281,16 @@ final class TraceableHttpKernelEventSubscriber implements EventSubscriberInterfa
 
     private function isAutoTraceable(Request $request): bool
     {
-        return InstrumentationTypeEnum::Auto === $this->instrumentationType;
+        if (InstrumentationTypeEnum::Auto !== $this->instrumentationType) {
+            return false;
+        }
+
+        $combinedExcludePaths = implode('|', $this->excludePaths);
+        if (preg_match("#{$combinedExcludePaths}#", $request->getPathInfo())) {
+            return false;
+        }
+
+        return true;
     }
 
     private function isAttributeTraceable(Request $request): bool
@@ -387,5 +401,13 @@ final class TraceableHttpKernelEventSubscriber implements EventSubscriberInterfa
     public function setInstrumentationType(InstrumentationTypeEnum $type): void
     {
         $this->instrumentationType = $type;
+    }
+
+    /**
+     * @param string[] $excludePaths
+     */
+    public function setExcludePaths(array $excludePaths): void
+    {
+        $this->excludePaths = $excludePaths;
     }
 }

--- a/src/OpenTelemetryBundle.php
+++ b/src/OpenTelemetryBundle.php
@@ -5,6 +5,7 @@ namespace FriendsOfOpenTelemetry\OpenTelemetryBundle;
 use Composer\InstalledVersions;
 use FriendsOfOpenTelemetry\OpenTelemetryBundle\DependencyInjection\Compiler\CacheInstrumentationPass;
 use FriendsOfOpenTelemetry\OpenTelemetryBundle\DependencyInjection\Compiler\HttpClientInstrumentationPass;
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\DependencyInjection\Compiler\SetHttpKernelTracingExcludePathsPass;
 use FriendsOfOpenTelemetry\OpenTelemetryBundle\DependencyInjection\Compiler\SetInstrumentationTypePass;
 use FriendsOfOpenTelemetry\OpenTelemetryBundle\DependencyInjection\Compiler\TracerLocatorPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -30,6 +31,7 @@ final class OpenTelemetryBundle extends Bundle
 
         $container->addCompilerPass(new CacheInstrumentationPass());
         $container->addCompilerPass(new HttpClientInstrumentationPass());
+        $container->addCompilerPass(new SetHttpKernelTracingExcludePathsPass());
 
         $container->addCompilerPass(new TracerLocatorPass());
     }

--- a/tests/Functional/Application/config/packages/open_telemetry.yaml
+++ b/tests/Functional/Application/config/packages/open_telemetry.yaml
@@ -92,3 +92,12 @@ open_telemetry:
     exporters:
       in_memory:
         dsn: in-memory://default
+when@auto:
+  open_telemetry:
+    instrumentation:
+      http_kernel:
+        type: auto
+        tracing:
+          enabled: true
+          exclude_paths:
+            - ^/auto-exclude$

--- a/tests/Functional/Application/src/Controller/AutoTraceableController.php
+++ b/tests/Functional/Application/src/Controller/AutoTraceableController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class AutoTraceableController extends AbstractController
+{
+    #[Route('/auto-traceable')]
+    public function index(): Response
+    {
+        return $this->json([
+            'status' => 'ok',
+        ]);
+    }
+
+    #[Route('/auto-exclude')]
+    public function exclude(): Response
+    {
+        return $this->json([
+            'status' => 'ok',
+        ]);
+    }
+}

--- a/tests/Functional/Instrumentation/HttpKernel/HttpKernelAttributeTracingTest.php
+++ b/tests/Functional/Instrumentation/HttpKernel/HttpKernelAttributeTracingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\Tests\Functional\Instrumentation;
+namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\Tests\Functional\Instrumentation\HttpKernel;
 
 use App\Kernel;
 use FriendsOfOpenTelemetry\OpenTelemetryBundle\Tests\Functional\LoggingTestCaseTrait;
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Zalas\PHPUnit\Globals\Attribute\Env;
 
 #[Env('KERNEL_CLASS', Kernel::class)]
-class HttpKernelTracingTest extends WebTestCase
+class HttpKernelAttributeTracingTest extends WebTestCase
 {
     use TracingTestCaseTrait;
     use LoggingTestCaseTrait;

--- a/tests/Functional/Instrumentation/HttpKernel/HttpKernelAutoTracingTest.php
+++ b/tests/Functional/Instrumentation/HttpKernel/HttpKernelAutoTracingTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\Tests\Functional\Instrumentation\HttpKernel;
+
+use App\Kernel;
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Tests\Functional\TracingTestCaseTrait;
+use OpenTelemetry\SDK\Trace\StatusData;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Zalas\PHPUnit\Globals\Attribute\Env;
+
+#[Env('KERNEL_CLASS', Kernel::class)]
+#[Env('APP_ENV', 'auto')]
+class HttpKernelAutoTracingTest extends WebTestCase
+{
+    use TracingTestCaseTrait;
+
+    public function testSuccess(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/auto-traceable');
+
+        static::assertResponseIsSuccessful();
+        static::assertSame('{"status":"ok"}', $client->getResponse()->getContent());
+
+        self::assertSpansCount(1);
+
+        $mainSpan = self::getSpans()[0];
+        self::assertSpanName($mainSpan, 'app_autotraceable_index');
+        self::assertSpanStatus($mainSpan, StatusData::ok());
+        self::assertSpanAttributes($mainSpan, [
+            'url.full' => 'http://localhost/auto-traceable',
+            'http.request.method' => 'GET',
+            'url.path' => '/auto-traceable',
+            'symfony.kernel.http.host' => 'localhost',
+            'url.scheme' => 'http',
+            'network.protocol.version' => '1.1',
+            'user_agent.original' => 'Symfony BrowserKit',
+            'network.peer.address' => '127.0.0.1',
+            'symfony.kernel.net.peer_ip' => '127.0.0.1',
+            'server.address' => 'localhost',
+            'server.port' => 80,
+            'http.route' => 'app_autotraceable_index',
+            'http.response.status_code' => Response::HTTP_OK,
+        ]);
+        self::assertSpanEventsCount($mainSpan, 0);
+    }
+
+    public function testExclude(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/auto-exclude');
+
+        static::assertResponseIsSuccessful();
+        static::assertSame('{"status":"ok"}', $client->getResponse()->getContent());
+
+        self::assertSpansCount(0);
+    }
+}

--- a/tests/Unit/DependencyInjection/Compiler/SetHttpKernelTracingExcludePathsPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/SetHttpKernelTracingExcludePathsPassTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\DependencyInjection\Compiler\SetHttpKernelTracingExcludePathsPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+#[CoversClass(SetHttpKernelTracingExcludePathsPass::class)]
+class SetHttpKernelTracingExcludePathsPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new SetHttpKernelTracingExcludePathsPass());
+
+        $container->setDefinition('open_telemetry.instrumentation.http_kernel.trace.event_subscriber', new Definition());
+    }
+
+    public function testNoExcludePaths(): void
+    {
+        $this->compile();
+
+        $httpKernel = $this->container->getDefinition('open_telemetry.instrumentation.http_kernel.trace.event_subscriber');
+        self::assertEquals([], $httpKernel->getMethodCalls());
+    }
+
+    public function testInstrumentationType(): void
+    {
+        $this->container->setParameter('open_telemetry.instrumentation.http_kernel.tracing.exclude_paths', ['/test']);
+
+        $this->compile();
+
+        $httpKernel = $this->container->getDefinition('open_telemetry.instrumentation.http_kernel.trace.event_subscriber');
+        self::assertEquals([['setExcludePaths', [['/test']]]], $httpKernel->getMethodCalls());
+    }
+}

--- a/tests/Unit/DependencyInjection/ConfigurationFormatTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationFormatTest.php
@@ -68,6 +68,7 @@ final class ConfigurationFormatTest extends AbstractExtensionConfigurationTestCa
                     'type' => 'auto',
                     'tracing' => [
                         'enabled' => false,
+                        'exclude_paths' => [],
                     ],
                     'metering' => [
                         'enabled' => false,

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -82,6 +82,7 @@ final class ConfigurationTest extends TestCase
                     'type' => 'auto',
                     'tracing' => [
                         'enabled' => false,
+                        'exclude_paths' => [],
                     ],
                     'metering' => [
                         'enabled' => false,
@@ -203,6 +204,9 @@ final class ConfigurationTest extends TestCase
 
                         # The tracer to use, defaults to `traces.default_tracer` or first tracer in `traces.tracers`
                         tracer:               ~
+
+                        # Exclude paths from auto instrumentation
+                        exclude_paths:        []
                     metering:
                         enabled:              false
 

--- a/tests/Unit/DependencyInjection/OpenTelemetryExtensionTest.php
+++ b/tests/Unit/DependencyInjection/OpenTelemetryExtensionTest.php
@@ -132,7 +132,7 @@ class OpenTelemetryExtensionTest extends AbstractExtensionTestCase
                 'cache' => $instrumentationConfig,
                 'console' => ['tracing' => ['enabled' => true], 'type' => 'attribute'],
                 'http_client' => $instrumentationConfig,
-                'http_kernel' => ['tracing' => ['enabled' => true], 'type' => 'attribute'],
+                'http_kernel' => ['tracing' => ['enabled' => true, 'exclude_paths' => ['/test']], 'type' => 'attribute'],
                 'mailer' => $instrumentationConfig,
                 'messenger' => $instrumentationConfig,
                 'twig' => $instrumentationConfig,
@@ -148,5 +148,6 @@ class OpenTelemetryExtensionTest extends AbstractExtensionTestCase
 
         self::assertContainerBuilderHasParameter('open_telemetry.instrumentation.console.type', InstrumentationTypeEnum::Attribute);
         self::assertContainerBuilderHasParameter('open_telemetry.instrumentation.http_kernel.type', InstrumentationTypeEnum::Attribute);
+        self::assertContainerBuilderHasParameter('open_telemetry.instrumentation.http_kernel.tracing.exclude_paths', ['/test']);
     }
 }


### PR DESCRIPTION
Closes #115 