### PR TITLE
feat(Instrumentation/Metrics): flush metrics on Console & Kernel TERMINATE events

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -9,7 +9,7 @@
         "package.json",
         "package-lock.json",
         "composer.lock",
-        "tests/Functional/DummyMeterServiceTest.php"
+        "tests/*"
     ],
     "AllowedContentTypes": [],
     "PassedFiles": [],

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "doctrine/doctrine-migrations-bundle": "^3.4",
         "doctrine/orm": "^2.18 || ^3.3",
         "ergebnis/composer-normalize": "^2.45",
-        "matthiasnoback/symfony-config-test": "^5.2",
+        "matthiasnoback/symfony-config-test": "^6.0",
         "matthiasnoback/symfony-dependency-injection-test": "^6.0",
         "mcaskill/composer-exclude-files": "^4.0",
         "nyholm/symfony-bundle-test": "^3.0",
@@ -74,7 +74,7 @@
         "symfony/twig-bundle": "^7.2",
         "symfony/yaml": "^7.2",
         "twig/twig": "^3.18",
-        "zalas/phpunit-globals": "^3.5"
+        "zalas/phpunit-globals": "^4.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "Needed to enable Doctrine DBAL & ORM instrumentation",

--- a/src/DependencyInjection/OpenTelemetryMetricsExtension.php
+++ b/src/DependencyInjection/OpenTelemetryMetricsExtension.php
@@ -115,7 +115,9 @@ final class OpenTelemetryMetricsExtension
                 isset($config['exporter']) ? new Reference($config['exporter']) : null,
                 $filter,
                 new Reference('open_telemetry.resource_info'),
-            ]);
+            ])
+            ->addTag('open_telemetry.metrics.provider')
+        ;
     }
 
     /**

--- a/src/Instrumentation/Symfony/Console/ObservableConsoleEventSubscriber.php
+++ b/src/Instrumentation/Symfony/Console/ObservableConsoleEventSubscriber.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\Console;
+
+use OpenTelemetry\SDK\Metrics\MeterProviderInterface;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class ObservableConsoleEventSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        /**
+         * @var list<MeterProviderInterface>
+         */
+        private readonly iterable $locator,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ConsoleEvents::TERMINATE => [
+                ['flush', -10000],
+            ],
+        ];
+    }
+
+    public function flush(ConsoleTerminateEvent $event): void
+    {
+        foreach ($this->locator as $provider) {
+            $provider->shutdown();
+        }
+    }
+}

--- a/src/Instrumentation/Symfony/Console/TraceableConsoleEventSubscriber.php
+++ b/src/Instrumentation/Symfony/Console/TraceableConsoleEventSubscriber.php
@@ -56,6 +56,11 @@ final class TraceableConsoleEventSubscriber implements EventSubscriberInterface,
         ];
     }
 
+    public static function getSubscribedServices(): array
+    {
+        return [TracerInterface::class];
+    }
+
     public function startSpan(ConsoleCommandEvent $event): void
     {
         $command = $event->getCommand();
@@ -170,11 +175,6 @@ final class TraceableConsoleEventSubscriber implements EventSubscriberInterface,
 
         return InstrumentationTypeEnum::Attribute === $this->instrumentationType
             && true === $traceable instanceof Traceable;
-    }
-
-    public static function getSubscribedServices(): array
-    {
-        return [TracerInterface::class];
     }
 
     public function setInstrumentationType(InstrumentationTypeEnum $type): void

--- a/src/Instrumentation/Symfony/HttpKernel/ObservableHttpKernelEventSubscriber.php
+++ b/src/Instrumentation/Symfony/HttpKernel/ObservableHttpKernelEventSubscriber.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\HttpKernel;
+
+use OpenTelemetry\SDK\Metrics\MeterProviderInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class ObservableHttpKernelEventSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        /**
+         * @var list<MeterProviderInterface>
+         */
+        private readonly iterable $locator,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::TERMINATE => [
+                ['flush', 10000],
+            ],
+        ];
+    }
+
+    public function flush(TerminateEvent $event): void
+    {
+        foreach ($this->locator as $provider) {
+            $provider->shutdown();
+        }
+    }
+}

--- a/src/Instrumentation/Symfony/HttpKernel/TraceableHttpKernelEventSubscriber.php
+++ b/src/Instrumentation/Symfony/HttpKernel/TraceableHttpKernelEventSubscriber.php
@@ -104,6 +104,11 @@ final class TraceableHttpKernelEventSubscriber implements EventSubscriberInterfa
         ];
     }
 
+    public static function getSubscribedServices(): array
+    {
+        return [TracerInterface::class];
+    }
+
     public function startRequest(RequestEvent $event): void
     {
         $request = $event->getRequest();
@@ -391,11 +396,6 @@ final class TraceableHttpKernelEventSubscriber implements EventSubscriberInterfa
         }
 
         return $headerAttributes;
-    }
-
-    public static function getSubscribedServices(): array
-    {
-        return [TracerInterface::class];
     }
 
     public function setInstrumentationType(InstrumentationTypeEnum $type): void

--- a/src/Resources/config/services_metering_instrumentation.php
+++ b/src/Resources/config/services_metering_instrumentation.php
@@ -1,0 +1,27 @@
+<?php
+
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\Console\ObservableConsoleEventSubscriber;
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Symfony\HttpKernel\ObservableHttpKernelEventSubscriber;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        ->defaults()
+        ->private()
+
+        // Console
+        ->set('open_telemetry.instrumentation.console.metric.event_subscriber', ObservableConsoleEventSubscriber::class)
+            ->args([tagged_iterator('open_telemetry.metrics.provider')])
+            ->tag('kernel.event_subscriber')
+            ->tag('monolog.logger', ['channel' => 'open_telemetry'])
+
+        // HTTP Kernel
+        ->set('open_telemetry.instrumentation.http_kernel.metric.event_subscriber', ObservableHttpKernelEventSubscriber::class)
+            ->args([tagged_iterator('open_telemetry.metrics.provider')])
+            ->tag('kernel.event_subscriber')
+            ->tag('monolog.logger', ['channel' => 'open_telemetry'])
+
+    ;
+};

--- a/src/Resources/config/services_tracing_instrumentation.php
+++ b/src/Resources/config/services_tracing_instrumentation.php
@@ -37,6 +37,7 @@ return static function (ContainerConfigurator $container): void {
         ->set('open_telemetry.instrumentation.console.trace.event_subscriber', TraceableConsoleEventSubscriber::class)
             ->arg('$tracer', service('open_telemetry.traces.default_tracer'))
             ->tag('kernel.event_subscriber')
+            ->tag('container.service_subscriber')
             ->tag('monolog.logger', ['channel' => 'open_telemetry'])
 
         // Doctrine
@@ -56,6 +57,7 @@ return static function (ContainerConfigurator $container): void {
             ->arg('$propagator', service('open_telemetry.propagator_text_map.noop'))
             ->arg('$propagationGetter', service('open_telemetry.propagation_getter.headers'))
             ->tag('kernel.event_subscriber')
+            ->tag('container.service_subscriber')
             ->tag('monolog.logger', ['channel' => 'open_telemetry'])
 
         ->set('open_telemetry.instrumentation.http_kernel.trace.route_loader', TraceableRouteLoader::class)

--- a/tests/Functional/Application/config/packages/open_telemetry.yaml
+++ b/tests/Functional/Application/config/packages/open_telemetry.yaml
@@ -12,6 +12,8 @@ open_telemetry:
       type: attribute
       tracing:
         enabled: true
+      metering:
+        enabled: true
     doctrine:
       tracing:
         enabled: true
@@ -21,6 +23,8 @@ open_telemetry:
     http_kernel:
       type: attribute
       tracing:
+        enabled: true
+      metering:
         enabled: true
     mailer:
       tracing:

--- a/tests/Functional/Application/src/Command/Observable/ManualCommand.php
+++ b/tests/Functional/Application/src/Command/Observable/ManualCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Command\Observable;
+
+use OpenTelemetry\API\Metrics\MeterInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand('observable:manual-command')]
+class ManualCommand extends Command
+{
+    public function __construct(
+        private readonly MeterInterface $meter,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $counter = $this->meter->createCounter('manual');
+
+        $counter->add(1);
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Functional/Application/src/Command/Traceable/AutoCommand.php
+++ b/tests/Functional/Application/src/Command/Traceable/AutoCommand.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace App\Command;
+namespace App\Command\Traceable;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand('dummy-command')]
-class DummyCommand extends Command
+#[AsCommand('traceable:auto-command')]
+class AutoCommand extends Command
 {
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/tests/Functional/Application/src/Command/Traceable/DummyCommand.php
+++ b/tests/Functional/Application/src/Command/Traceable/DummyCommand.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace App\Command;
+namespace App\Command\Traceable;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand('auto-command')]
-class AutoCommand extends Command
+#[AsCommand('traceable:dummy-command')]
+class DummyCommand extends Command
 {
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/tests/Functional/Application/src/Command/Traceable/FallbackCommand.php
+++ b/tests/Functional/Application/src/Command/Traceable/FallbackCommand.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace App\Command;
+namespace App\Command\Traceable;
 
 use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Attribute\Traceable;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[Traceable(tracer: 'open_telemetry.traces.tracers.fallback')]
-#[AsCommand('fallback-command')]
+#[AsCommand('traceable:fallback-command')]
 class FallbackCommand extends TraceableCommand
 {
 }

--- a/tests/Functional/Application/src/Command/Traceable/TraceableCommand.php
+++ b/tests/Functional/Application/src/Command/Traceable/TraceableCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Command;
+namespace App\Command\Traceable;
 
 use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Attribute\Traceable;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[Traceable]
-#[AsCommand('traceable-command')]
+#[AsCommand('traceable:traceable-command')]
 class TraceableCommand extends Command
 {
     protected function configure(): void

--- a/tests/Functional/Application/src/Controller/Observable/AbstractObservableController.php
+++ b/tests/Functional/Application/src/Controller/Observable/AbstractObservableController.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Controller\Observable;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+abstract class AbstractObservableController extends AbstractController
+{
+}

--- a/tests/Functional/Application/src/Controller/Observable/ManualObservableController.php
+++ b/tests/Functional/Application/src/Controller/Observable/ManualObservableController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Observable;
+
+use OpenTelemetry\API\Metrics\MeterInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+class ManualObservableController extends AbstractObservableController
+{
+    public function __construct(
+        private readonly MeterInterface $meter,
+    ) {
+    }
+
+    #[Route('/manual-observable')]
+    public function index(): JsonResponse
+    {
+        $counter = $this->meter->createCounter('manual');
+
+        $counter->add(1);
+
+        return $this->json(['status' => 'ok']);
+    }
+}

--- a/tests/Functional/Application/src/Controller/Traceable/AbstractTraceableController.php
+++ b/tests/Functional/Application/src/Controller/Traceable/AbstractTraceableController.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Controller\Traceable;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+abstract class AbstractTraceableController extends AbstractController
+{
+}

--- a/tests/Functional/Application/src/Controller/Traceable/ActionTraceableController.php
+++ b/tests/Functional/Application/src/Controller/Traceable/ActionTraceableController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Controller;
+namespace App\Controller\Traceable;
 
 use App\Entity\Dummy;
 use Doctrine\ORM\EntityManagerInterface;
@@ -10,12 +10,11 @@ use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\SemConv\TraceAttributes;
 use Psr\Log\LoggerInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-class ActionTraceableController extends AbstractController
+class ActionTraceableController extends AbstractTraceableController
 {
     #[Traceable]
     #[Route('/ok', methods: ['GET'])]

--- a/tests/Functional/Application/src/Controller/Traceable/AutoTraceableController.php
+++ b/tests/Functional/Application/src/Controller/Traceable/AutoTraceableController.php
@@ -2,13 +2,12 @@
 
 declare(strict_types=1);
 
-namespace App\Controller;
+namespace App\Controller\Traceable;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-class AutoTraceableController extends AbstractController
+class AutoTraceableController extends AbstractTraceableController
 {
     #[Route('/auto-traceable')]
     public function index(): Response

--- a/tests/Functional/Application/src/Controller/Traceable/AutowireTracerController.php
+++ b/tests/Functional/Application/src/Controller/Traceable/AutowireTracerController.php
@@ -1,17 +1,16 @@
 <?php
 
-namespace App\Controller;
+namespace App\Controller\Traceable;
 
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\SemConv\TraceAttributes;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-class AutowireTracerController extends AbstractController
+class AutowireTracerController extends AbstractTraceableController
 {
     public function __construct(
         #[Autowire('@open_telemetry.traces.tracers.fallback')]

--- a/tests/Functional/Application/src/Controller/Traceable/ClassInvokeTraceableController.php
+++ b/tests/Functional/Application/src/Controller/Traceable/ClassInvokeTraceableController.php
@@ -1,16 +1,15 @@
 <?php
 
-namespace App\Controller;
+namespace App\Controller\Traceable;
 
 use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Attribute\Traceable;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Traceable(tracer: 'open_telemetry.traces.tracers.fallback')]
-class FallbackTraceableController extends AbstractController
+#[Traceable]
+class ClassInvokeTraceableController extends AbstractTraceableController
 {
-    #[Route('/fallback-traceable', methods: ['GET'])]
+    #[Route('/class-invoke-traceable', methods: ['GET'])]
     public function __invoke(): Response
     {
         return $this->json([

--- a/tests/Functional/Application/src/Controller/Traceable/ClassTraceableController.php
+++ b/tests/Functional/Application/src/Controller/Traceable/ClassTraceableController.php
@@ -1,18 +1,17 @@
 <?php
 
-namespace App\Controller;
+namespace App\Controller\Traceable;
 
 use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Attribute\Traceable;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\SemConv\TraceAttributes;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[Traceable]
-class ClassTraceableController extends AbstractController
+class ClassTraceableController extends AbstractTraceableController
 {
     public function __construct(private readonly TracerInterface $tracer)
     {

--- a/tests/Functional/Application/src/Controller/Traceable/DualTracerController.php
+++ b/tests/Functional/Application/src/Controller/Traceable/DualTracerController.php
@@ -1,19 +1,18 @@
 <?php
 
-namespace App\Controller;
+namespace App\Controller\Traceable;
 
 use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Attribute\Traceable;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\SemConv\TraceAttributes;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[Traceable]
-class DualTracerController extends AbstractController
+class DualTracerController extends AbstractTraceableController
 {
     #[Route('/fallback-dual-tracer', methods: ['GET'])]
     public function fallback(

--- a/tests/Functional/Application/src/Controller/Traceable/FallbackTraceableController.php
+++ b/tests/Functional/Application/src/Controller/Traceable/FallbackTraceableController.php
@@ -1,16 +1,15 @@
 <?php
 
-namespace App\Controller;
+namespace App\Controller\Traceable;
 
 use FriendsOfOpenTelemetry\OpenTelemetryBundle\Instrumentation\Attribute\Traceable;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Traceable]
-class ClassInvokeTraceableController extends AbstractController
+#[Traceable(tracer: 'open_telemetry.traces.tracers.fallback')]
+class FallbackTraceableController extends AbstractTraceableController
 {
-    #[Route('/class-invoke-traceable', methods: ['GET'])]
+    #[Route('/fallback-traceable', methods: ['GET'])]
     public function __invoke(): Response
     {
         return $this->json([

--- a/tests/Functional/Application/src/Controller/Traceable/NotTraceableClassController.php
+++ b/tests/Functional/Application/src/Controller/Traceable/NotTraceableClassController.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace App\Controller;
+namespace App\Controller\Traceable;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-class NotTraceableClassController extends AbstractController
+class NotTraceableClassController extends AbstractTraceableController
 {
     #[Route('/not-traceable-class', methods: ['GET'])]
     public function index(): Response

--- a/tests/Functional/Application/templates/fragment.html.twig
+++ b/tests/Functional/Application/templates/fragment.html.twig
@@ -1,4 +1,4 @@
 <h1>fragment</h1>
 <p>
-    {{ render(controller('App\\Controller\\ActionTraceableController::view')) }}
+    {{ render(controller('App\\Controller\\Traceable\\ActionTraceableController::view')) }}
 </p>

--- a/tests/Functional/DummyMeterServiceTest.php
+++ b/tests/Functional/DummyMeterServiceTest.php
@@ -29,7 +29,7 @@ final class DummyMeterServiceTest extends KernelTestCase
     {
         $this->meterService->count([21, 21]);
         $this->meterService->count([21, 21]);
-        self::shutdownMetrics();
+        self::flushMetrics();
 
         self::assertMetricsCount(1);
 
@@ -61,7 +61,7 @@ final class DummyMeterServiceTest extends KernelTestCase
     public function testGauge(): void
     {
         $this->meterService->gauge([21, 21]);
-        self::shutdownMetrics();
+        self::flushMetrics();
 
         self::assertMetricsCount(1);
 
@@ -92,7 +92,7 @@ final class DummyMeterServiceTest extends KernelTestCase
     {
         $this->meterService->upDownCount([21, -21]);
         $this->meterService->upDownCount([-21, 21]);
-        self::shutdownMetrics();
+        self::flushMetrics();
 
         self::assertMetricsCount(1);
 
@@ -125,7 +125,7 @@ final class DummyMeterServiceTest extends KernelTestCase
     {
         $this->meterService->histogram([21, 42]);
         $this->meterService->histogram([84, 42]);
-        self::shutdownMetrics();
+        self::flushMetrics();
 
         self::assertMetricsCount(1);
 

--- a/tests/Functional/Instrumentation/Console/ConsoleAttributeTracingTest.php
+++ b/tests/Functional/Instrumentation/Console/ConsoleAttributeTracingTest.php
@@ -26,17 +26,17 @@ class ConsoleAttributeTracingTest extends KernelTestCase
 
         $tester = new ApplicationTester($application);
 
-        $tester->run(['command' => 'traceable-command']);
+        $tester->run(['command' => 'traceable:traceable-command']);
         $tester->assertCommandIsSuccessful();
 
         self::assertSpansCount(1);
 
         $mainSpan = self::getSpans()[0];
-        self::assertSpanName($mainSpan, 'traceable-command');
+        self::assertSpanName($mainSpan, 'traceable:traceable-command');
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributes($mainSpan, [
             'code.function.name' => 'execute',
-            'code.namespace' => 'App\Command\TraceableCommand',
+            'code.namespace' => 'App\Command\Traceable\TraceableCommand',
             'symfony.console.exit_code' => 0,
         ]);
         self::assertSpanEventsCount($mainSpan, 0);
@@ -52,7 +52,7 @@ class ConsoleAttributeTracingTest extends KernelTestCase
         $tester = new ApplicationTester($application);
 
         $tester->run([
-            'command' => 'traceable-command',
+            'command' => 'traceable:traceable-command',
             '--fail' => true,
         ]);
         self::assertSame(1, $tester->getStatusCode());
@@ -60,11 +60,11 @@ class ConsoleAttributeTracingTest extends KernelTestCase
         self::assertSpansCount(1);
 
         $mainSpan = self::getSpans()[0];
-        self::assertSpanName($mainSpan, 'traceable-command');
+        self::assertSpanName($mainSpan, 'traceable:traceable-command');
         self::assertSpanStatus($mainSpan, StatusData::error());
         self::assertSpanAttributes($mainSpan, [
             'code.function.name' => 'execute',
-            'code.namespace' => 'App\Command\TraceableCommand',
+            'code.namespace' => 'App\Command\Traceable\TraceableCommand',
             'symfony.console.exit_code' => 1,
         ]);
         self::assertSpanEventsCount($mainSpan, 0);
@@ -80,7 +80,7 @@ class ConsoleAttributeTracingTest extends KernelTestCase
         $tester = new ApplicationTester($application);
 
         $tester->run([
-            'command' => 'traceable-command',
+            'command' => 'traceable:traceable-command',
             '--throw' => true,
         ], [
             'verbosity' => OutputInterface::VERBOSITY_QUIET,
@@ -93,11 +93,11 @@ class ConsoleAttributeTracingTest extends KernelTestCase
         self::assertSpansCount(1);
 
         $mainSpan = self::getSpans()[0];
-        self::assertSpanName($mainSpan, 'traceable-command');
+        self::assertSpanName($mainSpan, 'traceable:traceable-command');
         self::assertSpanStatus($mainSpan, StatusData::error());
         self::assertSpanAttributes($mainSpan, [
             'code.function.name' => 'execute',
-            'code.namespace' => 'App\Command\TraceableCommand',
+            'code.namespace' => 'App\Command\Traceable\TraceableCommand',
             'symfony.console.exit_code' => 1,
         ]);
 
@@ -121,7 +121,7 @@ class ConsoleAttributeTracingTest extends KernelTestCase
 
         $tester = new ApplicationTester($application);
 
-        $tester->run(['command' => 'fallback-command']);
+        $tester->run(['command' => 'traceable:fallback-command']);
         $tester->assertCommandIsSuccessful();
 
         self::assertSpansCount(0);
@@ -129,11 +129,11 @@ class ConsoleAttributeTracingTest extends KernelTestCase
         self::assertSpansCount(1, 'open_telemetry.traces.exporters.fallback');
 
         $mainSpan = self::getSpans('open_telemetry.traces.exporters.fallback')[0];
-        self::assertSpanName($mainSpan, 'fallback-command');
+        self::assertSpanName($mainSpan, 'traceable:fallback-command');
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributes($mainSpan, [
             'code.function.name' => 'execute',
-            'code.namespace' => 'App\Command\FallbackCommand',
+            'code.namespace' => 'App\Command\Traceable\FallbackCommand',
             'symfony.console.exit_code' => 0,
         ]);
         self::assertSpanEventsCount($mainSpan, 0);

--- a/tests/Functional/Instrumentation/Console/ConsoleAutoTracingTest.php
+++ b/tests/Functional/Instrumentation/Console/ConsoleAutoTracingTest.php
@@ -25,17 +25,17 @@ class ConsoleAutoTracingTest extends KernelTestCase
 
         $tester = new ApplicationTester($application);
 
-        $tester->run(['command' => 'auto-command']);
+        $tester->run(['command' => 'traceable:auto-command']);
         self::assertSame(0, $tester->getStatusCode());
 
         self::assertSpansCount(1);
 
         $mainSpan = self::getSpans()[0];
-        self::assertSpanName($mainSpan, 'auto-command');
+        self::assertSpanName($mainSpan, 'traceable:auto-command');
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributes($mainSpan, [
             'code.function.name' => 'execute',
-            'code.namespace' => 'App\Command\AutoCommand',
+            'code.namespace' => 'App\Command\Traceable\AutoCommand',
             'symfony.console.exit_code' => 0,
         ]);
         self::assertSpanEventsCount($mainSpan, 0);
@@ -50,7 +50,7 @@ class ConsoleAutoTracingTest extends KernelTestCase
 
         $tester = new ApplicationTester($application);
 
-        $tester->run(['command' => 'dummy-command']);
+        $tester->run(['command' => 'traceable:dummy-command']);
         self::assertSame(0, $tester->getStatusCode());
 
         self::assertSpansCount(0);

--- a/tests/Functional/Instrumentation/Console/ConsoleManualMeteringTest.php
+++ b/tests/Functional/Instrumentation/Console/ConsoleManualMeteringTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\Tests\Functional\Instrumentation\Console;
+
+use App\Kernel;
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Tests\Functional\MeterTestCaseTrait;
+use OpenTelemetry\SDK\Metrics\Data\NumberDataPoint;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\ApplicationTester;
+use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+use Zalas\PHPUnit\Globals\Attribute\Env;
+
+#[Env('KERNEL_CLASS', Kernel::class)]
+#[Env('APP_ENV', 'auto')]
+class ConsoleManualMeteringTest extends KernelTestCase
+{
+    use MeterTestCaseTrait;
+    use VarDumperTestTrait;
+
+    public function testSuccess(): void
+    {
+        $kernel = self::bootKernel();
+
+        $application = new Application($kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+
+        $tester->run(['command' => 'observable:manual-command']);
+        self::assertSame(0, $tester->getStatusCode());
+
+        self::assertMetricsCount(1);
+
+        $metric = self::getMetrics()[0];
+
+        self::assertMetricName($metric, 'manual');
+        self::assertMetricDataInstanceOf(NumberDataPoint::class, $metric);
+        self::assertDumpMatchesFormat(<<<DUMP
+        OpenTelemetry\SDK\Metrics\Data\Sum {
+          +dataPoints: array:1 [
+            0 => OpenTelemetry\SDK\Metrics\Data\NumberDataPoint {
+              +value: 1
+              +attributes: OpenTelemetry\SDK\Common\Attribute\Attributes {
+                -attributes: []
+                -droppedAttributesCount: 0
+              }
+              +startTimestamp: %d
+              +timestamp: %d
+              +exemplars: []
+            }
+          ]
+          +temporality: "Delta"
+          +monotonic: true
+        }
+        DUMP, $metric->data);
+    }
+}

--- a/tests/Functional/Instrumentation/HttpKernel/HttpKernelAttributeTracingTest.php
+++ b/tests/Functional/Instrumentation/HttpKernel/HttpKernelAttributeTracingTest.php
@@ -28,7 +28,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         self::assertSpansCount(1);
 
         $mainSpan = self::getSpans()[0];
-        self::assertSpanName($mainSpan, 'app_actiontraceable_ok');
+        self::assertSpanName($mainSpan, 'app_traceable_actiontraceable_ok');
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributes($mainSpan, [
             'url.full' => 'http://localhost/ok',
@@ -42,7 +42,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
             'symfony.kernel.net.peer_ip' => '127.0.0.1',
             'server.address' => 'localhost',
             'server.port' => 80,
-            'http.route' => 'app_actiontraceable_ok',
+            'http.route' => 'app_traceable_actiontraceable_ok',
             'http.response.status_code' => Response::HTTP_OK,
         ]);
         self::assertSpanEventsCount($mainSpan, 0);
@@ -59,7 +59,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         self::assertSpansCount(1);
 
         $mainSpan = self::getSpans()[0];
-        self::assertSpanName($mainSpan, 'app_actiontraceable_failure');
+        self::assertSpanName($mainSpan, 'app_traceable_actiontraceable_failure');
         self::assertSpanStatus($mainSpan, StatusData::error());
         self::assertSpanAttributes($mainSpan, [
             'url.full' => 'http://localhost/failure',
@@ -73,7 +73,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
             'symfony.kernel.net.peer_ip' => '127.0.0.1',
             'server.address' => 'localhost',
             'server.port' => 80,
-            'http.route' => 'app_actiontraceable_failure',
+            'http.route' => 'app_traceable_actiontraceable_failure',
             'http.response.status_code' => Response::HTTP_SERVICE_UNAVAILABLE,
         ]);
         self::assertSpanEventsCount($mainSpan, 0);
@@ -91,7 +91,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         $spans = self::getSpans();
 
         $mainSpan = $spans[array_key_last($spans)];
-        self::assertSpanName($mainSpan, 'app_actiontraceable_exception');
+        self::assertSpanName($mainSpan, 'app_traceable_actiontraceable_exception');
         self::assertSpanStatus($mainSpan, StatusData::error());
         self::assertSpanAttributes($mainSpan, [
             'url.full' => 'http://localhost/exception',
@@ -105,7 +105,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
             'symfony.kernel.net.peer_ip' => '127.0.0.1',
             'server.address' => 'localhost',
             'server.port' => 80,
-            'http.route' => 'app_actiontraceable_exception',
+            'http.route' => 'app_traceable_actiontraceable_exception',
             'http.response.status_code' => Response::HTTP_INTERNAL_SERVER_ERROR,
         ]);
         self::assertSpanEventsCount($mainSpan, 1);
@@ -129,7 +129,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         self::assertSpansCount(1);
 
         $mainSpan = self::getSpans()[0];
-        self::assertSpanName($mainSpan, 'app_classinvoketraceable__invoke');
+        self::assertSpanName($mainSpan, 'app_traceable_classinvoketraceable__invoke');
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributes($mainSpan, [
             'url.full' => 'http://localhost/class-invoke-traceable',
@@ -143,7 +143,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
             'symfony.kernel.net.peer_ip' => '127.0.0.1',
             'server.address' => 'localhost',
             'server.port' => 80,
-            'http.route' => 'app_classinvoketraceable__invoke',
+            'http.route' => 'app_traceable_classinvoketraceable__invoke',
             'http.response.status_code' => Response::HTTP_OK,
         ]);
         self::assertSpanEventsCount($mainSpan, 0);
@@ -160,7 +160,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         self::assertSpansCount(1);
 
         $mainSpan = self::getSpans()[0];
-        self::assertSpanName($mainSpan, 'app_classtraceable_index');
+        self::assertSpanName($mainSpan, 'app_traceable_classtraceable_index');
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributes($mainSpan, [
             'url.full' => 'http://localhost/class-traceable',
@@ -174,7 +174,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
             'symfony.kernel.net.peer_ip' => '127.0.0.1',
             'server.address' => 'localhost',
             'server.port' => 80,
-            'http.route' => 'app_classtraceable_index',
+            'http.route' => 'app_traceable_classtraceable_index',
             'http.response.status_code' => Response::HTTP_OK,
         ]);
         self::assertSpanEventsCount($mainSpan, 0);
@@ -195,7 +195,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         self::assertSpanStatus($manualSpan, StatusData::ok());
         self::assertSpanAttributes($manualSpan, [
             'code.function.name' => 'manual',
-            'code.namespace' => 'App\Controller\ClassTraceableController',
+            'code.namespace' => 'App\Controller\Traceable\ClassTraceableController',
         ]);
         self::assertSpanEventsCount($manualSpan, 1);
         $manualSpanEvent = $manualSpan->getEvents()[0];
@@ -205,7 +205,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         ]);
 
         $mainSpan = self::getSpans()[1];
-        self::assertSpanName($mainSpan, 'app_classtraceable_manual');
+        self::assertSpanName($mainSpan, 'app_traceable_classtraceable_manual');
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributes($mainSpan, [
             'url.full' => 'http://localhost/class-manual',
@@ -219,7 +219,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
             'symfony.kernel.net.peer_ip' => '127.0.0.1',
             'server.address' => 'localhost',
             'server.port' => 80,
-            'http.route' => 'app_classtraceable_manual',
+            'http.route' => 'app_traceable_classtraceable_manual',
             'http.response.status_code' => Response::HTTP_OK,
         ]);
 
@@ -259,7 +259,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         self::assertSpansCount(1, 'open_telemetry.traces.exporters.fallback');
 
         $mainSpan = self::getSpans('open_telemetry.traces.exporters.fallback')[0];
-        self::assertSpanName($mainSpan, 'app_fallbacktraceable__invoke');
+        self::assertSpanName($mainSpan, 'app_traceable_fallbacktraceable__invoke');
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributes($mainSpan, [
             'url.full' => 'http://localhost/fallback-traceable',
@@ -273,7 +273,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
             'symfony.kernel.net.peer_ip' => '127.0.0.1',
             'server.address' => 'localhost',
             'server.port' => 80,
-            'http.route' => 'app_fallbacktraceable__invoke',
+            'http.route' => 'app_traceable_fallbacktraceable__invoke',
             'http.response.status_code' => Response::HTTP_OK,
         ]);
         self::assertSpanEventsCount($mainSpan, 0);
@@ -294,7 +294,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         self::assertSpanStatus($manualSpan, StatusData::ok());
         self::assertSpanAttributes($manualSpan, [
             'code.function.name' => 'manual',
-            'code.namespace' => 'App\Controller\ActionTraceableController',
+            'code.namespace' => 'App\Controller\Traceable\ActionTraceableController',
         ]);
         self::assertSpanEventsCount($manualSpan, 1);
         $manualSpanEvent = $manualSpan->getEvents()[0];
@@ -304,7 +304,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         ]);
 
         $mainSpan = self::getSpans()[1];
-        self::assertSpanName($mainSpan, 'app_actiontraceable_manual');
+        self::assertSpanName($mainSpan, 'app_traceable_actiontraceable_manual');
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributes($mainSpan, [
             'url.full' => 'http://localhost/manual-action',
@@ -318,7 +318,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
             'symfony.kernel.net.peer_ip' => '127.0.0.1',
             'server.address' => 'localhost',
             'server.port' => 80,
-            'http.route' => 'app_actiontraceable_manual',
+            'http.route' => 'app_traceable_actiontraceable_manual',
             'http.response.status_code' => Response::HTTP_OK,
         ]);
 
@@ -342,7 +342,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         self::assertSpanStatus($manualSpan, StatusData::ok());
         self::assertSpanAttributes($manualSpan, [
             'code.function.name' => 'manual',
-            'code.namespace' => 'App\Controller\AutowireTracerController',
+            'code.namespace' => 'App\Controller\Traceable\AutowireTracerController',
         ]);
         self::assertSpanEventsCount($manualSpan, 1);
         $manualSpanEvent = $manualSpan->getEvents()[0];
@@ -363,7 +363,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         self::assertSpansCount(1);
 
         $mainSpan = self::getSpans()[0];
-        self::assertSpanName($mainSpan, 'app_dualtracer_fallback');
+        self::assertSpanName($mainSpan, 'app_traceable_dualtracer_fallback');
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributes($mainSpan, [
             'url.full' => 'http://localhost/fallback-dual-tracer',
@@ -377,7 +377,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
             'symfony.kernel.net.peer_ip' => '127.0.0.1',
             'server.address' => 'localhost',
             'server.port' => 80,
-            'http.route' => 'app_dualtracer_fallback',
+            'http.route' => 'app_traceable_dualtracer_fallback',
             'http.response.status_code' => 200,
         ]);
 
@@ -388,7 +388,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         self::assertSpanStatus($manualSpan, StatusData::ok());
         self::assertSpanAttributes($manualSpan, [
             'code.function.name' => 'manual',
-            'code.namespace' => 'App\Controller\DualTracerController',
+            'code.namespace' => 'App\Controller\Traceable\DualTracerController',
         ]);
         self::assertSpanEventsCount($manualSpan, 1);
         $manualSpanEvent = $manualSpan->getEvents()[0];
@@ -415,7 +415,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         self::assertSpanStatus($manualSpan, StatusData::ok());
         self::assertSpanAttributes($manualSpan, [
             'code.function.name' => 'manual',
-            'code.namespace' => 'App\Controller\DualTracerController',
+            'code.namespace' => 'App\Controller\Traceable\DualTracerController',
         ]);
         self::assertSpanEventsCount($manualSpan, 1);
         $manualSpanEvent = $manualSpan->getEvents()[0];
@@ -425,7 +425,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         ]);
 
         $mainSpan = self::getSpans()[1];
-        self::assertSpanName($mainSpan, 'app_dualtracer_main');
+        self::assertSpanName($mainSpan, 'app_traceable_dualtracer_main');
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributes($mainSpan, [
             'url.full' => 'http://localhost/main-dual-tracer',
@@ -439,7 +439,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
             'symfony.kernel.net.peer_ip' => '127.0.0.1',
             'server.address' => 'localhost',
             'server.port' => 80,
-            'http.route' => 'app_dualtracer_main',
+            'http.route' => 'app_traceable_dualtracer_main',
             'http.response.status_code' => 200,
         ]);
 
@@ -457,7 +457,7 @@ class HttpKernelAttributeTracingTest extends WebTestCase
         self::assertSpansCount(1);
 
         $mainSpan = self::getSpans()[0];
-        self::assertSpanName($mainSpan, 'app_actiontraceable_logspancontext');
+        self::assertSpanName($mainSpan, 'app_traceable_actiontraceable_logspancontext');
 
         $log = self::getLog('A detailed log message.', Level::Debug->getName());
         self::assertNotNull($log);

--- a/tests/Functional/Instrumentation/HttpKernel/HttpKernelAutoTracingTest.php
+++ b/tests/Functional/Instrumentation/HttpKernel/HttpKernelAutoTracingTest.php
@@ -26,7 +26,7 @@ class HttpKernelAutoTracingTest extends WebTestCase
         self::assertSpansCount(1);
 
         $mainSpan = self::getSpans()[0];
-        self::assertSpanName($mainSpan, 'app_autotraceable_index');
+        self::assertSpanName($mainSpan, 'app_traceable_autotraceable_index');
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributes($mainSpan, [
             'url.full' => 'http://localhost/auto-traceable',
@@ -40,7 +40,7 @@ class HttpKernelAutoTracingTest extends WebTestCase
             'symfony.kernel.net.peer_ip' => '127.0.0.1',
             'server.address' => 'localhost',
             'server.port' => 80,
-            'http.route' => 'app_autotraceable_index',
+            'http.route' => 'app_traceable_autotraceable_index',
             'http.response.status_code' => Response::HTTP_OK,
         ]);
         self::assertSpanEventsCount($mainSpan, 0);

--- a/tests/Functional/Instrumentation/HttpKernel/HttpKernelManualMeteringTest.php
+++ b/tests/Functional/Instrumentation/HttpKernel/HttpKernelManualMeteringTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\Tests\Functional\Instrumentation\HttpKernel;
+
+use App\Kernel;
+use FriendsOfOpenTelemetry\OpenTelemetryBundle\Tests\Functional\MeterTestCaseTrait;
+use OpenTelemetry\SDK\Metrics\Data\NumberDataPoint;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+use Zalas\PHPUnit\Globals\Attribute\Env;
+
+#[Env('KERNEL_CLASS', Kernel::class)]
+#[Env('APP_ENV', 'auto')]
+class HttpKernelManualMeteringTest extends WebTestCase
+{
+    use MeterTestCaseTrait;
+    use VarDumperTestTrait;
+
+    public function testManual(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/manual-observable');
+
+        static::assertResponseIsSuccessful();
+        static::assertSame('{"status":"ok"}', $client->getResponse()->getContent());
+
+        self::assertMetricsCount(1);
+
+        $metric = self::getMetrics()[0];
+
+        self::assertMetricName($metric, 'manual');
+        self::assertMetricDataInstanceOf(NumberDataPoint::class, $metric);
+        self::assertDumpMatchesFormat(<<<DUMP
+        OpenTelemetry\SDK\Metrics\Data\Sum {
+          +dataPoints: array:1 [
+            0 => OpenTelemetry\SDK\Metrics\Data\NumberDataPoint {
+              +value: 1
+              +attributes: OpenTelemetry\SDK\Common\Attribute\Attributes {
+                -attributes: []
+                -droppedAttributesCount: 0
+              }
+              +startTimestamp: %d
+              +timestamp: %d
+              +exemplars: []
+            }
+          ]
+          +temporality: "Delta"
+          +monotonic: true
+        }
+        DUMP, $metric->data);
+    }
+}

--- a/tests/Functional/Instrumentation/TwigTracingTest.php
+++ b/tests/Functional/Instrumentation/TwigTracingTest.php
@@ -81,7 +81,7 @@ class TwigTracingTest extends WebTestCase
         self::assertSpanName($nativeFragmentSpan, 'HTTP GET');
         self::assertSpanStatus($nativeFragmentSpan, StatusData::ok());
         self::assertSpanAttributes($nativeFragmentSpan, [
-            'url.full' => 'http://localhost/_fragment?_path=_format%3Dhtml%26_locale%3Den%26_controller%3DApp%255CController%255CActionTraceableController%253A%253Aview',
+            'url.full' => 'http://localhost/_fragment?_path=_format%3Dhtml%26_locale%3Den%26_controller%3DApp%255CController%255CTraceable%255CActionTraceableController%253A%253Aview',
             'http.request.method' => 'GET',
             'url.path' => '/_fragment',
             'symfony.kernel.http.host' => 'localhost',
@@ -103,7 +103,7 @@ class TwigTracingTest extends WebTestCase
         self::assertSpanEventsCount($fragmentSpan, 0);
 
         $mainSpan = self::getSpans()[4];
-        self::assertSpanName($mainSpan, 'app_actiontraceable_segment');
+        self::assertSpanName($mainSpan, 'app_traceable_actiontraceable_segment');
         self::assertSpanStatus($mainSpan, StatusData::ok());
         self::assertSpanAttributes($mainSpan, [
             'url.full' => 'http://localhost/fragment',
@@ -117,7 +117,7 @@ class TwigTracingTest extends WebTestCase
             'symfony.kernel.net.peer_ip' => '127.0.0.1',
             'server.address' => 'localhost',
             'server.port' => 80,
-            'http.route' => 'app_actiontraceable_segment',
+            'http.route' => 'app_traceable_actiontraceable_segment',
             'http.response.status_code' => 200,
         ]);
         self::assertSpanEventsCount($mainSpan, 0);

--- a/tests/Functional/MeterTestCaseTrait.php
+++ b/tests/Functional/MeterTestCaseTrait.php
@@ -3,6 +3,7 @@
 namespace FriendsOfOpenTelemetry\OpenTelemetryBundle\Tests\Functional;
 
 use OpenTelemetry\SDK\Metrics\Data\Metric;
+use OpenTelemetry\SDK\Metrics\MeterProviderInterface;
 use OpenTelemetry\SDK\Metrics\MetricExporter\InMemoryExporter;
 
 trait MeterTestCaseTrait
@@ -15,9 +16,10 @@ trait MeterTestCaseTrait
         return $exporter;
     }
 
-    protected static function shutdownMetrics(?string $providerId = null): void
+    protected static function flushMetrics(?string $providerId = null): void
     {
         $provider = self::getContainer()->get($providerId ?? 'open_telemetry.metrics.providers.default');
+        self::assertInstanceOf(MeterProviderInterface::class, $provider);
         $provider->shutdown();
     }
 

--- a/tests/Unit/DependencyInjection/OpenTelemetryMetricsExtensionTest.php
+++ b/tests/Unit/DependencyInjection/OpenTelemetryMetricsExtensionTest.php
@@ -270,6 +270,7 @@ class OpenTelemetryMetricsExtensionTest extends AbstractExtensionTestCase
             2,
             new Reference('open_telemetry.resource_info'),
         );
+        self::assertContainerBuilderHasServiceDefinitionWithTag('open_telemetry.metrics.providers.main', 'open_telemetry.metrics.provider');
         $provider = $this->container->getDefinition('open_telemetry.metrics.providers.main');
         self::assertEquals([new Reference(sprintf('open_telemetry.metrics.provider_factory.%s', $type)), 'createProvider'], $provider->getFactory());
     }

--- a/tests/Unit/Fixtures/yml/metrics-provider-tag.yml
+++ b/tests/Unit/Fixtures/yml/metrics-provider-tag.yml
@@ -1,0 +1,24 @@
+open_telemetry:
+  service:
+    namespace: 'FriendsOfOpenTelemetry/OpenTelemetry'
+    name: 'Test'
+    version: '0.0.0'
+    environment: test
+  instrumentation:
+    console:
+      metering:
+        enabled: true
+    http_kernel:
+      metering:
+        enabled: true
+  metrics:
+    meters:
+      main:
+        provider: 'open_telemetry.metrics.providers.default'
+    providers:
+      default:
+        type: default
+        exporter: 'open_telemetry.metrics.exporters.otlp'
+    exporters:
+      otlp:
+        dsn: http+otlp://localhost


### PR DESCRIPTION
This PR allows to shutdown every registered metric provider on Console & Kernel `TERMINATE` events.

Make sure to enable metering instrumentation for `console` and `http_kernel` components:

```yaml
open_telemetry:
# ...
  instrumentation:
    console:
      metering:
        enabled: true
    http_kernel:
      metering:
        enabled: true
```

Closes #156