### PR TITLE
fix(OpenTelemetry/Metric): use named argument for InMemoryExporter instanciation

### DIFF
--- a/src/OpenTelemetry/Metric/MetricExporter/InMemoryMetricExporterFactory.php
+++ b/src/OpenTelemetry/Metric/MetricExporter/InMemoryMetricExporterFactory.php
@@ -22,6 +22,6 @@ final class InMemoryMetricExporterFactory extends AbstractMetricExporterFactory
     {
         assert($options instanceof MetricExporterOptions);
 
-        return new InMemoryExporter($options->getTemporality()->toData());
+        return new InMemoryExporter(temporality: $options->getTemporality()->toData());
     }
 }


### PR DESCRIPTION
The 1.2.4 release of `open-telemetry/sdk` introduced a breaking change without notice, a new parameter has been introduced to the InMemoryExporter for Trace, Metric and Log.

Check out the following PR for more info: https://github.com/open-telemetry/opentelemetry-php/pull/1559