### PR TITLE
fix(DependencyInjection): merge monolog.additional_channels parameter instead of being overwritten

### DIFF
--- a/src/DependencyInjection/OpenTelemetryExtension.php
+++ b/src/DependencyInjection/OpenTelemetryExtension.php
@@ -38,6 +38,13 @@ final class OpenTelemetryExtension extends ConfigurableExtension
     {
         $loader = new PhpFileLoader($container, new FileLocator(dirname(__DIR__).'/Resources/config'));
         $loader->load('services.php');
+
+        $channels = $container->hasParameter('monolog.additional_channels')
+            ? $container->getParameter('monolog.additional_channels')
+            : [];
+        $channels[] = 'open_telemetry';
+        $container->setParameter('monolog.additional_channels', array_unique($channels));
+
         $loader->load('services_transports.php');
         $loader->load('services_logs.php');
         $loader->load('services_metrics.php');

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -18,7 +18,6 @@ return static function (ContainerConfigurator $container): void {
     $container->parameters()
         ->set('open_telemetry.bundle.name', OpenTelemetryBundle::name())
         ->set('open_telemetry.bundle.version', OpenTelemetryBundle::version())
-        ->set('monolog.additional_channels', ['open_telemetry'])
     ;
 
     $container->services()

--- a/tests/Unit/DependencyInjection/OpenTelemetryExtensionTest.php
+++ b/tests/Unit/DependencyInjection/OpenTelemetryExtensionTest.php
@@ -65,6 +65,15 @@ class OpenTelemetryExtensionTest extends AbstractExtensionTestCase
         self::assertContainerBuilderHasParameter('monolog.additional_channels', ['open_telemetry']);
     }
 
+    public function testMonologAdditionalChannelsAreMerged(): void
+    {
+        $this->container->setParameter('monolog.additional_channels', ['deprecation']);
+
+        $this->load();
+
+        self::assertContainerBuilderHasParameter('monolog.additional_channels', ['deprecation', 'open_telemetry']);
+    }
+
     public function testDefaultServices(): void
     {
         $this->load();


### PR DESCRIPTION
- Fixes a bug where installing the bundle breaks existing Monolog channel configurations (e.g., `deprecation`) by overwriting the `monolog.additional_channels` parameter instead of merging into it
- Moves channel registration from `services.php` to `OpenTelemetryExtension::loadInternal()` where existing channels can be read and preserved
- Adds a regression test verifying pre-existing monolog channels survive bundle loading

Fixes #193